### PR TITLE
feat: live candlestick dashboard

### DIFF
--- a/src/app/pages/dashboard/candlestick-chart.component.css
+++ b/src/app/pages/dashboard/candlestick-chart.component.css
@@ -1,0 +1,10 @@
+.now-strip {
+  font-size: 12px;
+  margin-bottom: 4px;
+}
+canvas {
+  border: 1px solid #444;
+  width: 100%;
+  max-width: 600px;
+  height: 300px;
+}

--- a/src/app/pages/dashboard/candlestick-chart.component.html
+++ b/src/app/pages/dashboard/candlestick-chart.component.html
@@ -1,0 +1,5 @@
+<div class="now-strip">
+  {{instrumentKey}} — LTP: {{nowPrice ?? '—'}}
+  <span *ngIf="lastUpdate">({{ lastUpdate | date:'HH:mm:ss' }})</span>
+</div>
+<canvas width="600" height="300"></canvas>

--- a/src/app/pages/dashboard/candlestick-chart.component.ts
+++ b/src/app/pages/dashboard/candlestick-chart.component.ts
@@ -1,0 +1,98 @@
+import { Component, ElementRef, Input, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Subscription, filter } from 'rxjs';
+import { Candle, MarketDataService, Tick } from '../../services/market-data.service';
+
+@Component({
+  selector: 'app-candlestick-chart',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './candlestick-chart.component.html',
+  styleUrls: ['./candlestick-chart.component.css']
+})
+export class CandlestickChartComponent implements OnInit, OnDestroy {
+  @Input() instrumentKey!: string;
+  candles: Candle[] = [];
+  nowPrice?: number;
+  lastUpdate?: Date;
+  private sub?: Subscription;
+  private ctx?: CanvasRenderingContext2D;
+  private dirty = false;
+
+  constructor(private md: MarketDataService, private el: ElementRef) {}
+
+  ngOnInit() {
+    this.md.getCandles(this.instrumentKey).subscribe(cs => {
+      this.candles = cs;
+      this.dirty = true;
+    });
+    this.sub = this.md.ticks$
+      .pipe(filter(t => t.instrumentKey === this.instrumentKey))
+      .subscribe(t => this.handleTick(t));
+    requestAnimationFrame(() => this.renderLoop());
+  }
+
+  handleTick(t: Tick) {
+    this.nowPrice = t.ltp;
+    this.lastUpdate = new Date(t.ts);
+    const bucket = new Date(this.lastUpdate);
+    bucket.setSeconds(0,0);
+    const key = bucket.toISOString();
+    let last = this.candles[this.candles.length - 1];
+    if (!last || last.time !== key) {
+      last = { time: key, open: t.ltp, high: t.ltp, low: t.ltp, close: t.ltp, volume: t.volume };
+      this.candles.push(last);
+      if (this.candles.length > 240) this.candles.shift();
+    } else {
+      last.high = Math.max(last.high, t.ltp);
+      last.low = Math.min(last.low, t.ltp);
+      last.close = t.ltp;
+      last.volume += t.volume;
+    }
+    this.dirty = true;
+  }
+
+  renderLoop() {
+    if (this.dirty) {
+      this.draw();
+      this.dirty = false;
+    }
+    setTimeout(() => requestAnimationFrame(() => this.renderLoop()), 100);
+  }
+
+  draw() {
+    const canvas: HTMLCanvasElement = this.el.nativeElement.querySelector('canvas');
+    if (!canvas) return;
+    if (!this.ctx) this.ctx = canvas.getContext('2d')!;
+    const ctx = this.ctx;
+    const w = canvas.width;
+    const h = canvas.height;
+    ctx.clearRect(0, 0, w, h);
+    if (!this.candles.length) return;
+    const max = Math.max(...this.candles.map(c => c.high));
+    const min = Math.min(...this.candles.map(c => c.low));
+    const range = max - min || 1;
+    const bars = this.candles.slice(-240);
+    const barWidth = w / bars.length;
+    bars.forEach((c, i) => {
+      const openY = h - ((c.open - min) / range) * h;
+      const closeY = h - ((c.close - min) / range) * h;
+      const highY = h - ((c.high - min) / range) * h;
+      const lowY = h - ((c.low - min) / range) * h;
+      const x = i * barWidth + barWidth / 2;
+      ctx.strokeStyle = c.close >= c.open ? '#0a0' : '#a00';
+      ctx.beginPath();
+      ctx.moveTo(x, highY);
+      ctx.lineTo(x, lowY);
+      ctx.stroke();
+      ctx.fillStyle = ctx.strokeStyle;
+      const top = Math.min(openY, closeY);
+      const bottom = Math.max(openY, closeY);
+      ctx.fillRect(x - barWidth / 4, top, barWidth / 2, Math.max(bottom - top, 1));
+    });
+  }
+
+  ngOnDestroy() {
+    this.sub?.unsubscribe();
+  }
+}

--- a/src/app/pages/dashboard/dashboard.component.css
+++ b/src/app/pages/dashboard/dashboard.component.css
@@ -1,84 +1,29 @@
-:host {
+.toolbar {
   display: flex;
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  background-color: #0e1a1f;
-  color: #d8f0e3;
-  height: 100vh;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
 }
-
-.sidebar {
-  width: 220px;
-  background-color: #13252f;
+.token {
+  padding: 4px 8px;
+  border-radius: 4px;
+  background: #264;
+  color: #fff;
+}
+.token.warn {
+  background: #642;
+}
+.sse-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #a00;
+}
+.sse-dot.connected {
+  background: #0a0;
+}
+.charts {
   display: flex;
   flex-direction: column;
-  padding: 20px;
-  box-shadow: 2px 0 8px rgba(0, 0, 0, 0.4);
-}
-
-.sidebar h2 {
-  margin: 0 0 30px;
-  font-size: 20px;
-  color: #80ffd3;
-}
-
-.sidebar button {
-  background: #1f3b47;
-  border: none;
-  color: #80ffd3;
-  padding: 10px;
-  margin-bottom: 10px;
-  border-radius: 5px;
-  cursor: pointer;
-}
-
-.content {
-  flex: 1;
-  padding: 20px;
-  overflow-y: auto;
-}
-
-.header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 20px;
-}
-
-.header .status {
-  color: #80ffd3;
-}
-
-.chart {
-  background-color: #1a2e36;
-  height: 300px;
-  margin-bottom: 20px;
-  border-radius: 10px;
-  padding: 20px;
-}
-
-.options {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  margin-bottom: 20px;
-}
-
-.option-card {
-  flex: 1 1 calc(50% - 10px);
-  background-color: #1a2e36;
-  padding: 15px;
-  border-radius: 10px;
-  color: #d8f0e3;
-}
-
-.commentary {
-  background-color: #1a2e36;
-  padding: 20px;
-  border-radius: 10px;
-}
-
-.footer {
-  text-align: center;
-  color: #4f6c74;
-  margin-top: 20px;
+  gap: 20px;
 }

--- a/src/app/pages/dashboard/dashboard.component.html
+++ b/src/app/pages/dashboard/dashboard.component.html
@@ -1,36 +1,17 @@
-<div class="sidebar">
-  <h2>Auto Trader</h2>
-  <button (click)="goToLogin()">Login</button>
-  <button>Refresh Token</button>
-  <button>Settings</button>
+<div class="toolbar">
+  <span class="token" [class.warn]="authState && authState.expiresInSec < 300">
+    Token:
+    <ng-container *ngIf="authState?.ready; else disc">
+      Connected — expires in {{ (authState?.expiresInSec || 0) * 1000 | date:'HH:mm:ss':'UTC' }}
+    </ng-container>
+    <ng-template #disc>Disconnected</ng-template>
+  </span>
+  <span class="sse-dot" [class.connected]="(md.connection$ | async)"></span>
+  <select multiple [(ngModel)]="selected" (change)="onSelectionChange()" [ngModelOptions]="{standalone: true}">
+    <option *ngFor="let i of instruments" [ngValue]="i">{{ i }}</option>
+  </select>
 </div>
 
-<div class="content">
-  <div class="header">
-    <h1>Trading Dashboard</h1>
-    <div class="status">Token Expires in: {{ tokenExpiryTime }}</div>
-  </div>
-
-  <div class="chart">
-    <h3>Live Market Chart</h3>
-    <p>[Candlestick + Commentary Layer]</p>
-  </div>
-
-  <div class="options">
-    <div class="option-card">CE Option 1</div>
-    <div class="option-card">CE Option 2</div>
-    <div class="option-card">PE Option 1</div>
-    <div class="option-card">PE Option 2</div>
-    <div class="option-card">PE Option 3</div>
-    <div class="option-card">PE Option 4</div>
-  </div>
-
-  <div class="commentary">
-    <h3>Bot Commentary</h3>
-    <p>[Live interpretation of market dynamics and trade decisions]</p>
-  </div>
-
-  <div class="footer">
-    &copy; 2025 Auto Trading AI Dashboard
-  </div>
+<div class="charts">
+  <app-candlestick-chart *ngFor="let k of selected" [instrumentKey]="k"></app-candlestick-chart>
 </div>

--- a/src/app/pages/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/dashboard.component.ts
@@ -1,21 +1,54 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
+import { AuthService, AuthState } from '../../services/auth.service';
+import { MarketDataService } from '../../services/market-data.service';
+import { CandlestickChartComponent } from './candlestick-chart.component';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-dashboard',
+  standalone: true,
+  imports: [CommonModule, FormsModule, CandlestickChartComponent],
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.css']
 })
-export class DashboardComponent implements OnInit {
-  tokenExpiryTime: string = '00:30:00'; // dummy timer
+export class DashboardComponent implements OnInit, OnDestroy {
+  authState?: AuthState;
+  instruments: string[] = [];
+  selected: string[] = [];
+  private sub = new Subscription();
 
-  constructor(private router: Router) {}
+  constructor(
+    private router: Router,
+    private auth: AuthService,
+    public md: MarketDataService
+  ) {}
 
   ngOnInit(): void {
-    // WebSocket logic and token timer will be added here later
+    this.sub.add(this.auth.pollStatus().subscribe(s => (this.authState = s)));
+    this.sub.add(
+      this.md.listTracked().subscribe(list => {
+        this.instruments = list;
+        const saved = localStorage.getItem('instruments');
+        this.selected = saved ? JSON.parse(saved) : list;
+        this.md.connect(this.selected);
+      })
+    );
+  }
+
+  onSelectionChange() {
+    localStorage.setItem('instruments', JSON.stringify(this.selected));
+    this.md.connect(this.selected);
   }
 
   goToLogin(): void {
     this.router.navigate(['/login']);
+  }
+
+  ngOnDestroy() {
+    this.sub.unsubscribe();
+    this.md.disconnect();
   }
 }

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -23,9 +23,9 @@ export class AuthService {
     return this.http.post<void>(`${this.baseUrl}/auth/exchange?code=${code}`, null);
   }
 
-  /** 3️⃣  poll the backend every 3 s until it says `ready:true` */
+  /** 3️⃣  poll the backend every 15 s until it says `ready:true` */
   pollStatus(): Observable<AuthState> {
-    return timer(0, 3000).pipe(
+    return timer(0, 15000).pipe(
       switchMap(() => this.http.get<AuthState>(`${this.baseUrl}/auth/status`)),
       shareReplay(1)
     );

--- a/src/app/services/market-data.service.ts
+++ b/src/app/services/market-data.service.ts
@@ -1,0 +1,85 @@
+import { Injectable, NgZone, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { BehaviorSubject, Observable, Subject, catchError, map, of } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface Candle {
+  time: string; // ISO timestamp of minute start
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+export interface Tick {
+  instrumentKey: string;
+  ltp: number;
+  ts: string; // ISO timestamp
+  volume: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class MarketDataService {
+  private http = inject(HttpClient);
+  private zone = inject(NgZone);
+  private baseUrl = environment.apiBaseUrl;
+
+  private sse: EventSource | null = null;
+  private tickSub = new Subject<Tick>();
+  private connectionStatus = new BehaviorSubject<boolean>(false);
+  connection$ = this.connectionStatus.asObservable();
+  ticks$ = this.tickSub.asObservable();
+  private reconnectDelay = 1000;
+
+  /** attempt to fetch currently tracked instruments from backend */
+  listTracked(): Observable<string[]> {
+    return this.http
+      .get<{ instrumentKeys: string[] }>(`${this.baseUrl}/md/tracked`)
+      .pipe(
+        map(r => r.instrumentKeys),
+        catchError(() => of(['NIFTY_FUT', 'NIFTY_CE', 'NIFTY_PE']))
+      );
+  }
+
+  /** load historical candles */
+  getCandles(key: string): Observable<Candle[]> {
+    return this.http.get<Candle[]>(`${this.baseUrl}/md/candles?instrumentKey=${encodeURIComponent(key)}&tf=1m&lookback=120`);
+  }
+
+  /** connect to the streaming endpoint for the selected instruments */
+  connect(keys: string[]) {
+    this.disconnect();
+    if (!keys.length) return;
+    const params = keys.map(k => `instrumentKey=${encodeURIComponent(k)}`).join('&');
+    const url = `${this.baseUrl}/md/stream?${params}`;
+    const open = () => {
+      this.sse = new EventSource(url);
+      this.connectionStatus.next(true);
+      this.sse.onmessage = ev => {
+        this.zone.run(() => {
+          try {
+            const t = JSON.parse(ev.data) as Tick;
+            this.tickSub.next(t);
+          } catch (e) {}
+        });
+      };
+      this.sse.onerror = () => {
+        this.connectionStatus.next(false);
+        this.sse?.close();
+        setTimeout(open, this.reconnectDelay);
+        this.reconnectDelay = Math.min(this.reconnectDelay * 2, 30000);
+      };
+    };
+    open();
+  }
+
+  disconnect() {
+    if (this.sse) {
+      this.sse.close();
+      this.sse = null;
+    }
+    this.connectionStatus.next(false);
+    this.reconnectDelay = 1000;
+  }
+}


### PR DESCRIPTION
## Summary
- poll auth status every 15s and display token badge
- add instrument picker and SSE-driven candlestick charts
- implement market data service with auto-reconnecting stream

## Testing
- `npm run build`
- `npm test -- --watch=false` *(fails: No inputs were found in config file)*


------
https://chatgpt.com/codex/tasks/task_e_68acd242bff8832f868d2aa6b0941bd7