### PR TITLE
feat: add dark dashboard layout

### DIFF
--- a/src/app/pages/dashboard/dashboard.component.css
+++ b/src/app/pages/dashboard/dashboard.component.css
@@ -1,29 +1,95 @@
-.toolbar {
+.layout {
+  display: flex;
+  height: 100vh;
+  background: var(--bg);
+  color: var(--text-primary);
+}
+.sidebar {
+  width: 200px;
+  background: #111;
+  display: flex;
+  flex-direction: column;
+  padding: 1rem;
+}
+.sidebar .logo {
+  font-weight: bold;
+  margin-bottom: 1rem;
+}
+.sidebar nav a {
+  display: block;
+  padding: 0.5rem 0.75rem;
+  color: var(--text-secondary);
+  text-decoration: none;
+  border-radius: 6px;
+}
+.sidebar nav a.active {
+  background: var(--accent);
+  color: #fff;
+}
+.sidebar .spacer {
+  flex: 1;
+}
+.sidebar .mode {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-primary);
+  padding: 0.25rem 0.5rem;
+  border-radius: 6px;
+}
+.main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid var(--border);
+}
+.topbar .left {
   display: flex;
   align-items: center;
-  gap: 10px;
-  margin-bottom: 10px;
+  gap: 1rem;
+}
+.topbar .right {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
 }
 .token {
   padding: 4px 8px;
-  border-radius: 4px;
-  background: #264;
+  border-radius: 8px;
   color: #fff;
-}
-.token.warn {
-  background: #642;
 }
 .sse-dot {
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background: #a00;
+  background: var(--danger);
 }
 .sse-dot.connected {
-  background: #0a0;
+  background: var(--positive);
+}
+.content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+}
+.stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+.stat-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  padding: 0.5rem;
+  border-radius: 10px;
 }
 .charts {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
+  display: grid;
+  gap: 1rem;
 }

--- a/src/app/pages/dashboard/dashboard.component.html
+++ b/src/app/pages/dashboard/dashboard.component.html
@@ -1,17 +1,41 @@
-<div class="toolbar">
-  <span class="token" [class.warn]="authState && authState.expiresInSec < 300">
-    Token:
-    <ng-container *ngIf="authState?.ready; else disc">
-      Connected — expires in {{ (authState?.expiresInSec || 0) * 1000 | date:'HH:mm:ss':'UTC' }}
-    </ng-container>
-    <ng-template #disc>Disconnected</ng-template>
-  </span>
-  <span class="sse-dot" [class.connected]="(md.connection$ | async)"></span>
-  <select multiple [(ngModel)]="selected" (change)="onSelectionChange()" [ngModelOptions]="{standalone: true}">
-    <option *ngFor="let i of instruments" [ngValue]="i">{{ i }}</option>
-  </select>
-</div>
+<div class="layout">
+  <aside class="sidebar">
+    <div class="logo">Autobot</div>
+    <nav>
+      <a class="active">Dashboard</a>
+    </nav>
+    <div class="spacer"></div>
+    <button class="mode" (click)="toggleDark()">{{ darkMode ? 'Light' : 'Dark' }} Mode</button>
+  </aside>
 
-<div class="charts">
-  <app-candlestick-chart *ngFor="let k of selected" [instrumentKey]="k"></app-candlestick-chart>
+  <div class="main">
+    <header class="topbar">
+      <div class="left">
+        <span class="token" [style.background]="tokenColor()">
+          Token:
+          <ng-container *ngIf="authState?.ready; else disc">
+            Connected — expires in {{ tokenCountdown() }}
+          </ng-container>
+          <ng-template #disc>Disconnected</ng-template>
+        </span>
+        <span class="sse-dot" [class.connected]="(md.connection$ | async)"></span>
+      </div>
+      <div class="right">
+        <button *ngIf="!authState?.ready" (click)="loginWithUpstox()">Login with Upstox</button>
+        <select multiple [(ngModel)]="selected" (change)="onSelectionChange()" [ngModelOptions]="{standalone: true}">
+          <option *ngFor="let i of instruments" [ngValue]="i">{{ i }}</option>
+        </select>
+      </div>
+    </header>
+
+    <div class="content">
+      <div class="stats">
+        <div class="stat-card" *ngFor="let k of selected">{{ k }} LTP: {{ nowLtp[k] || '-' }}</div>
+        <div class="stat-card">Subscribed: {{ selected.length }}</div>
+      </div>
+      <div class="charts">
+        <app-candlestick-chart *ngFor="let k of selected" [instrumentKey]="k"></app-candlestick-chart>
+      </div>
+    </div>
+  </div>
 </div>

--- a/src/app/pages/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/dashboard.component.ts
@@ -1,11 +1,11 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { Router } from '@angular/router';
 import { AuthService, AuthState } from '../../services/auth.service';
 import { MarketDataService } from '../../services/market-data.service';
 import { CandlestickChartComponent } from './candlestick-chart.component';
 import { Subscription } from 'rxjs';
+import { formatCountdown } from '../../utils/time';
 
 @Component({
   selector: 'app-dashboard',
@@ -18,22 +18,38 @@ export class DashboardComponent implements OnInit, OnDestroy {
   authState?: AuthState;
   instruments: string[] = [];
   selected: string[] = [];
+  nowLtp: Record<string, number> = {};
+  darkMode = true;
   private sub = new Subscription();
 
   constructor(
-    private router: Router,
     private auth: AuthService,
     public md: MarketDataService
   ) {}
 
   ngOnInit(): void {
-    this.sub.add(this.auth.pollStatus().subscribe(s => (this.authState = s)));
+    const storedDark = localStorage.getItem('darkMode');
+    this.darkMode = storedDark !== '0';
+    document.body.classList.toggle('light', !this.darkMode);
+
+    this.sub.add(
+      this.auth.pollStatus().subscribe(s => {
+        this.authState = s;
+      })
+    );
+
     this.sub.add(
       this.md.listTracked().subscribe(list => {
         this.instruments = list;
         const saved = localStorage.getItem('instruments');
         this.selected = saved ? JSON.parse(saved) : list;
         this.md.connect(this.selected);
+      })
+    );
+
+    this.sub.add(
+      this.md.ticks$.subscribe(t => {
+        this.nowLtp[t.instrumentKey] = t.ltp;
       })
     );
   }
@@ -43,8 +59,28 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.md.connect(this.selected);
   }
 
-  goToLogin(): void {
-    this.router.navigate(['/login']);
+  loginWithUpstox(): void {
+    this.auth.getLoginUrl().subscribe({
+      next: url => (window.location.href = url),
+    });
+  }
+
+  tokenCountdown(): string {
+    return formatCountdown(this.authState?.expiresInSec || 0);
+  }
+
+  tokenColor(): string {
+    if (!this.authState?.ready) return 'var(--danger)';
+    const sec = this.authState.expiresInSec;
+    if (sec > 1800) return 'var(--positive)';
+    if (sec > 300) return 'var(--warning)';
+    return 'var(--danger)';
+  }
+
+  toggleDark() {
+    this.darkMode = !this.darkMode;
+    document.body.classList.toggle('light', !this.darkMode);
+    localStorage.setItem('darkMode', this.darkMode ? '1' : '0');
   }
 
   ngOnDestroy() {

--- a/src/app/services/market-data.service.ts
+++ b/src/app/services/market-data.service.ts
@@ -30,7 +30,8 @@ export class MarketDataService {
   private connectionStatus = new BehaviorSubject<boolean>(false);
   connection$ = this.connectionStatus.asObservable();
   ticks$ = this.tickSub.asObservable();
-  private reconnectDelay = 1000;
+  private delays = [1000, 2000, 5000, 10000];
+  private delayIndex = 0;
 
   /** attempt to fetch currently tracked instruments from backend */
   listTracked(): Observable<string[]> {
@@ -67,10 +68,12 @@ export class MarketDataService {
       this.sse.onerror = () => {
         this.connectionStatus.next(false);
         this.sse?.close();
-        setTimeout(open, this.reconnectDelay);
-        this.reconnectDelay = Math.min(this.reconnectDelay * 2, 30000);
+        const delay = this.delays[this.delayIndex];
+        setTimeout(open, delay);
+        if (this.delayIndex < this.delays.length - 1) this.delayIndex++;
       };
     };
+    this.delayIndex = 0;
     open();
   }
 
@@ -80,6 +83,6 @@ export class MarketDataService {
       this.sse = null;
     }
     this.connectionStatus.next(false);
-    this.reconnectDelay = 1000;
+    this.delayIndex = 0;
   }
 }

--- a/src/app/utils/time.ts
+++ b/src/app/utils/time.ts
@@ -1,0 +1,8 @@
+export function formatCountdown(totalSeconds: number): string {
+  const hrs = Math.floor(totalSeconds / 3600);
+  const mins = Math.floor((totalSeconds % 3600) / 60);
+  const secs = Math.floor(totalSeconds % 60);
+  return `${hrs.toString().padStart(2, '0')}:${mins.toString().padStart(2, '0')}:${secs
+    .toString()
+    .padStart(2, '0')}`;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,1 +1,21 @@
-/* You can add global styles to this file, and also import other style files */
+:root {
+  --bg: #0B0B0F;
+  --card-bg: #14141B;
+  --border: #23232D;
+  --text-primary: #EDEDF2;
+  --text-secondary: #A7A7B2;
+  --accent: #7C3AED;
+  --positive: #22C55E;
+  --warning: #F59E0B;
+  --danger: #EF4444;
+}
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text-primary);
+  font-family: Arial, sans-serif;
+}
+body.light {
+  background: #fff;
+  color: #000;
+}


### PR DESCRIPTION
## Summary
- implement dark themed dashboard with sidebar, top bar, and stat cards
- show token countdown with color coding and SSE connection status
- add reusable time formatter and improve SSE reconnection backoff

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No inputs were found in config file 'tsconfig.spec.json')*

------
https://chatgpt.com/codex/tasks/task_e_68acd959da00832f99e6651ce9ad693d