### PR TITLE
feat: wire dashboard to backend

### DIFF
--- a/src/app/pages/dashboard/candlestick-chart.component.css
+++ b/src/app/pages/dashboard/candlestick-chart.component.css
@@ -5,6 +5,5 @@
 canvas {
   border: 1px solid #444;
   width: 100%;
-  max-width: 600px;
-  height: 300px;
+  display: block;
 }

--- a/src/app/pages/dashboard/candlestick-chart.component.html
+++ b/src/app/pages/dashboard/candlestick-chart.component.html
@@ -2,4 +2,4 @@
   {{instrumentKey}} — LTP: {{nowPrice ?? '—'}}
   <span *ngIf="lastUpdate">({{ lastUpdate | date:'HH:mm:ss' }})</span>
 </div>
-<canvas width="600" height="300"></canvas>
+<canvas [attr.width]="width" [attr.height]="height"></canvas>

--- a/src/app/pages/dashboard/candlestick-chart.component.ts
+++ b/src/app/pages/dashboard/candlestick-chart.component.ts
@@ -12,6 +12,8 @@ import { Candle, MarketDataService, Tick } from '../../services/market-data.serv
 })
 export class CandlestickChartComponent implements OnInit, OnDestroy {
   @Input() instrumentKey!: string;
+  @Input() width = 600;
+  @Input() height = 300;
   candles: Candle[] = [];
   nowPrice?: number;
   lastUpdate?: Date;

--- a/src/app/pages/dashboard/dashboard.component.css
+++ b/src/app/pages/dashboard/dashboard.component.css
@@ -62,14 +62,17 @@
   padding: 4px 8px;
   border-radius: 8px;
   color: #fff;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
-.sse-dot {
+.token .dot {
   width: 10px;
   height: 10px;
   border-radius: 50%;
   background: var(--danger);
 }
-.sse-dot.connected {
+.token .dot.connected {
   background: var(--positive);
 }
 .content {
@@ -90,6 +93,25 @@
   border-radius: 10px;
 }
 .charts {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
+}
+
+.option-charts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1rem;
+}
+
+@media (max-width: 768px) {
+  .sidebar {
+    display: none;
+  }
+  .stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .option-charts {
+    grid-template-columns: 1fr;
+  }
 }

--- a/src/app/pages/dashboard/dashboard.component.html
+++ b/src/app/pages/dashboard/dashboard.component.html
@@ -12,29 +12,42 @@
     <header class="topbar">
       <div class="left">
         <span class="token" [style.background]="tokenColor()">
+          <span class="dot" [class.connected]="authState?.ready"></span>
           Token:
           <ng-container *ngIf="authState?.ready; else disc">
             Connected — expires in {{ tokenCountdown() }}
           </ng-container>
           <ng-template #disc>Disconnected</ng-template>
         </span>
-        <span class="sse-dot" [class.connected]="(md.connection$ | async)"></span>
       </div>
       <div class="right">
         <button *ngIf="!authState?.ready" (click)="loginWithUpstox()">Login with Upstox</button>
-        <select multiple [(ngModel)]="selected" (change)="onSelectionChange()" [ngModelOptions]="{standalone: true}">
-          <option *ngFor="let i of instruments" [ngValue]="i">{{ i }}</option>
+        <select *ngIf="authState?.ready" multiple [(ngModel)]="selectedOptions" (change)="onSelectionChange()" [ngModelOptions]="{standalone: true}">
+          <option *ngFor="let i of options" [ngValue]="i">{{ i }}</option>
         </select>
       </div>
     </header>
 
     <div class="content">
       <div class="stats">
-        <div class="stat-card" *ngFor="let k of selected">{{ k }} LTP: {{ nowLtp[k] || '-' }}</div>
-        <div class="stat-card">Subscribed: {{ selected.length }}</div>
+        <div class="stat-card" *ngFor="let k of [mainInstrument, ...selectedOptions]">{{ k }} LTP: {{ nowLtp[k] || '-' }}</div>
       </div>
       <div class="charts">
-        <app-candlestick-chart *ngFor="let k of selected" [instrumentKey]="k"></app-candlestick-chart>
+        <app-candlestick-chart
+          class="main-chart"
+          [instrumentKey]="mainInstrument"
+          [width]="800"
+          [height]="400"
+        ></app-candlestick-chart>
+        <div class="option-charts">
+          <app-candlestick-chart
+            class="mini-chart"
+            *ngFor="let k of selectedOptions"
+            [instrumentKey]="k"
+            [width]="400"
+            [height]="200"
+          ></app-candlestick-chart>
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/pages/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/dashboard.component.ts
@@ -16,8 +16,9 @@ import { formatCountdown } from '../../utils/time';
 })
 export class DashboardComponent implements OnInit, OnDestroy {
   authState?: AuthState;
-  instruments: string[] = [];
-  selected: string[] = [];
+  mainInstrument = 'NIFTY_FUT';
+  options: string[] = [];
+  selectedOptions: string[] = [];
   nowLtp: Record<string, number> = {};
   darkMode = true;
   private sub = new Subscription();
@@ -40,10 +41,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
     this.sub.add(
       this.md.listTracked().subscribe(list => {
-        this.instruments = list;
-        const saved = localStorage.getItem('instruments');
-        this.selected = saved ? JSON.parse(saved) : list;
-        this.md.connect(this.selected);
+        this.options = list.filter(k => k !== this.mainInstrument);
+        const saved = localStorage.getItem('options');
+        this.selectedOptions = saved ? JSON.parse(saved) : this.options;
+        this.md.connect([this.mainInstrument, ...this.selectedOptions]);
       })
     );
 
@@ -55,8 +56,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   onSelectionChange() {
-    localStorage.setItem('instruments', JSON.stringify(this.selected));
-    this.md.connect(this.selected);
+    localStorage.setItem('options', JSON.stringify(this.selectedOptions));
+    this.md.connect([this.mainInstrument, ...this.selectedOptions]);
   }
 
   loginWithUpstox(): void {

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,5 +1,4 @@
 export const environment = {
   production: true,
-  // API base URL now points to the AWS Elastic Beanstalk deployment
-  apiBaseUrl: 'autotradebot-env.eba-adnie9a5.eu-north-1.elasticbeanstalk.com'
-};            
+  apiBaseUrl: 'https://backendforautobot-production.up.railway.app'
+};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: false,
-  apiBaseUrl: 'http://localhost:8081'
+  apiBaseUrl: 'https://backendforautobot-production.up.railway.app'
 };


### PR DESCRIPTION
## Summary
- connect frontend to production backend
- render dark dashboard with token status and live charts
- add responsive layout for mobile

## Testing
- `npm test` *(fails: No inputs were found in config file '/workspace/frontendfortheautobot/tsconfig.spec.json')*

------
https://chatgpt.com/codex/tasks/task_e_68ad4d592d08832f8adacae17bbc26c8