### PR TITLE
feat: dark dashboard and live market data

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -4,7 +4,7 @@ import { DashboardComponent } from './pages/dashboard/dashboard.component';
 import { LoginComponent } from './pages/login/login.component';
 
 export const routes: Routes = [
-  { path: '', redirectTo: '/dashboard', pathMatch: 'full' },
+  { path: '', redirectTo: '/login', pathMatch: 'full' },
   { path: 'dashboard', component: DashboardComponent },
   { path: 'login', component: LoginComponent }
   // (optional) add other routes

--- a/src/app/pages/dashboard/candlestick-chart.component.css
+++ b/src/app/pages/dashboard/candlestick-chart.component.css
@@ -5,6 +5,5 @@
 canvas {
   border: 1px solid #444;
   width: 100%;
-  max-width: 600px;
-  height: 300px;
+  height: 100%;
 }

--- a/src/app/pages/dashboard/candlestick-chart.component.ts
+++ b/src/app/pages/dashboard/candlestick-chart.component.ts
@@ -65,8 +65,10 @@ export class CandlestickChartComponent implements OnInit, OnDestroy {
     if (!canvas) return;
     if (!this.ctx) this.ctx = canvas.getContext('2d')!;
     const ctx = this.ctx;
-    const w = canvas.width;
-    const h = canvas.height;
+    const w = canvas.clientWidth;
+    const h = canvas.clientHeight;
+    if (canvas.width !== w) canvas.width = w;
+    if (canvas.height !== h) canvas.height = h;
     ctx.clearRect(0, 0, w, h);
     if (!this.candles.length) return;
     const max = Math.max(...this.candles.map(c => c.high));

--- a/src/app/pages/dashboard/dashboard.component.css
+++ b/src/app/pages/dashboard/dashboard.component.css
@@ -58,6 +58,13 @@
   align-items: center;
   gap: 1rem;
 }
+.chip {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  padding: 2px 6px;
+  border-radius: 6px;
+  font-size: 0.8rem;
+}
 .token {
   padding: 4px 8px;
   border-radius: 8px;
@@ -92,4 +99,30 @@
 .charts {
   display: grid;
   gap: 1rem;
+  grid-template-columns: 2fr 1fr;
+  grid-template-areas: 'main opt1' 'main opt2';
+}
+.main-chart {
+  grid-area: main;
+  height: 400px;
+}
+.opt-chart:nth-child(2) {
+  grid-area: opt1;
+  height: 200px;
+}
+.opt-chart:nth-child(3) {
+  grid-area: opt2;
+  height: 200px;
+}
+@media (max-width: 768px) {
+  .charts {
+    grid-template-columns: 1fr;
+    grid-template-areas: 'main' 'opt1' 'opt2';
+  }
+  .main-chart {
+    height: 300px;
+  }
+  .opt-chart {
+    height: 200px;
+  }
 }

--- a/src/app/pages/dashboard/dashboard.component.html
+++ b/src/app/pages/dashboard/dashboard.component.html
@@ -21,29 +21,24 @@
         <span class="sse-dot" [class.connected]="(md.connection$ | async)"></span>
       </div>
       <div class="right">
-        <button *ngIf="!authState?.ready" (click)="loginWithUpstox()">Login with Upstox</button>
-        <select multiple [(ngModel)]="selectedOptions" (change)="onSelectionChange()" [ngModelOptions]="{standalone: true}">
-          <option *ngFor="let i of instruments" [ngValue]="i">{{ i }}</option>
-        </select>
+        <span class="chip" *ngFor="let k of combinedInstruments; trackBy: trackByKey">{{ k }}</span>
       </div>
     </header>
 
     <div class="content">
       <div class="stats">
-        <div class="stat-card" *ngFor="let k of combinedInstruments; trackBy: trackByKey">
-          {{ k }} LTP: {{ (nowLtp?.[k] ?? '-') }}
-        </div>
+        <div class="stat-card">FUT LTP: {{ nowLtp?.[mainInstrument] ?? '-' }}</div>
+        <div class="stat-card">CE LTP: {{ option1 ? (nowLtp?.[option1] ?? '-') : '-' }}</div>
+        <div class="stat-card">PE LTP: {{ option2 ? (nowLtp?.[option2] ?? '-') : '-' }}</div>
         <div class="stat-card">Subscribed: {{ combinedInstruments.length }}</div>
       </div>
       <div class="charts">
-        <app-candlestick-chart
-          *ngIf="mainInstrument"
-          [instrumentKey]="mainInstrument"></app-candlestick-chart>
-        <ng-container *ngIf="selectedOptions?.length">
-          <app-candlestick-chart
-            *ngFor="let k of selectedOptions; trackBy: trackByKey"
-            [instrumentKey]="k"></app-candlestick-chart>
-        </ng-container>
+        <div class="main-chart" *ngIf="mainInstrument">
+          <app-candlestick-chart [instrumentKey]="mainInstrument"></app-candlestick-chart>
+        </div>
+        <div class="opt-chart" *ngFor="let k of selectedOptions; trackBy: trackByKey">
+          <app-candlestick-chart [instrumentKey]="k"></app-candlestick-chart>
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/pages/login/login.component.css
+++ b/src/app/pages/login/login.component.css
@@ -1,0 +1,15 @@
+.login-wrapper {
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: var(--bg);
+}
+button {
+  padding: 0.75rem 1.5rem;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+}

--- a/src/app/pages/login/login.component.html
+++ b/src/app/pages/login/login.component.html
@@ -1,0 +1,3 @@
+<div class="login-wrapper">
+  <button (click)="login()">Login with Upstox</button>
+</div>

--- a/src/app/pages/login/login.component.ts
+++ b/src/app/pages/login/login.component.ts
@@ -1,44 +1,17 @@
 import { Component } from '@angular/core';
 import { AuthService } from '../../services/auth.service';
-import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-login',
-  template: `<div>Logging in...</div>`,
+  templateUrl: './login.component.html',
+  styleUrls: ['./login.component.css']
 })
 export class LoginComponent {
-  constructor(private auth: AuthService, private router: Router) {
-    this.autoLogin();
-  }
-autoLogin() {
-  const currentUrl = window.location.href;
-  const codeMatch = currentUrl.match(/[?&]code=([^&]+)/);
+  constructor(private auth: AuthService) {}
 
-  if (codeMatch && codeMatch[1]) {
-    const code = decodeURIComponent(codeMatch[1]);
-    console.log('🔐 Auth code received from redirect:', code);
-
-    this.auth.exchange(code).subscribe({
-      next: () => {
-        console.log('✅ Code exchanged, token saved');
-        setTimeout(() => this.router.navigate(['/dashboard']), 1000);
-      },
-      error: err => {
-        console.error('❌ Token exchange failed:', err);
-      },
-    });
-
-  } else {
-    console.log('📡 No code found in URL, redirecting to Upstox login...');
+  login() {
     this.auth.getLoginUrl().subscribe({
-      next: loginUrl => {
-        console.log('➡️ Redirecting to:', loginUrl);
-        window.location.href = loginUrl;
-      },
-      error: err => {
-        console.error('❌ Failed to get login URL:', err);
-      }
+      next: url => (window.location.href = url)
     });
   }
-}
 }

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -18,11 +18,6 @@ export class AuthService {
     return this.http.get<{ url: string }>(`${this.baseUrl}/auth/url`).pipe(map(r => r.url));
   }
 
-  /** 2️⃣  send the `code` that the user pasted */
-  exchange(code: string): Observable<void> {
-    return this.http.post<void>(`${this.baseUrl}/auth/exchange?code=${code}`, null);
-  }
-
   /** 3️⃣  poll the backend every 15 s until it says `ready:true` */
   pollStatus(): Observable<AuthState> {
     return timer(0, 15000).pipe(

--- a/src/app/services/market-data.service.ts
+++ b/src/app/services/market-data.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NgZone, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { BehaviorSubject, Observable, Subject, catchError, map, of } from 'rxjs';
+import { BehaviorSubject, Observable, Subject, catchError, of } from 'rxjs';
 import { environment } from '../../environments/environment';
 
 export interface Candle {
@@ -33,14 +33,11 @@ export class MarketDataService {
   private delays = [1000, 2000, 5000, 10000];
   private delayIndex = 0;
 
-  /** attempt to fetch currently tracked instruments from backend */
-  listTracked(): Observable<string[]> {
+  /** fetch selection of main instrument and options */
+  getSelection(): Observable<{ mainInstrument: string; options: string[] } | null> {
     return this.http
-      .get<{ instrumentKeys: string[] }>(`${this.baseUrl}/md/tracked`)
-      .pipe(
-        map(r => r.instrumentKeys),
-        catchError(() => of(['NIFTY_FUT', 'NIFTY_CE', 'NIFTY_PE']))
-      );
+      .get<{ mainInstrument: string; options: string[] }>(`${this.baseUrl}/md/selection`)
+      .pipe(catchError(() => of(null)));
   }
 
   /** load historical candles */

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,5 +1,4 @@
 export const environment = {
   production: true,
-  // API base URL now points to the AWS Elastic Beanstalk deployment
-  apiBaseUrl: 'autotradebot-env.eba-adnie9a5.eu-north-1.elasticbeanstalk.com'
-};            
+  apiBaseUrl: 'https://backendforautobot-production.up.railway.app'
+};


### PR DESCRIPTION
## Summary
- add Upstox login view and route
- implement dark dashboard with live token badge, instrument chips and candlestick charts
- connect market data stream and resize charts
- point prod environment to Railway backend

## Testing
- `npm test` *(fails: No inputs were found in config file)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ad5fcbaae8832f8d198d3c79d989fe