### PR TITLE
refactor: centralize API base

### DIFF
--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -11,17 +11,17 @@ export interface AuthState {
 @Injectable({ providedIn: 'root' })
 export class AuthService {
   private http = inject(HttpClient);
-  private baseUrl = environment.apiBaseUrl;
+  private apiBase = environment.apiBase;
 
   /** 1️⃣  ask the backend for the login-URL */
   getLoginUrl(): Observable<string> {
-    return this.http.get<{ url: string }>(`${this.baseUrl}/auth/url`).pipe(map(r => r.url));
+    return this.http.get<{ url: string }>(`${this.apiBase}/auth/url`).pipe(map(r => r.url));
   }
 
   /** 3️⃣  poll the backend every 15 s until it says `ready:true` */
   pollStatus(): Observable<AuthState> {
     return timer(0, 15000).pipe(
-      switchMap(() => this.http.get<AuthState>(`${this.baseUrl}/auth/status`)),
+      switchMap(() => this.http.get<AuthState>(`${this.apiBase}/auth/status`)),
       shareReplay(1)
     );
   }

--- a/src/app/services/market-data.service.ts
+++ b/src/app/services/market-data.service.ts
@@ -23,7 +23,7 @@ export interface Tick {
 export class MarketDataService {
   private http = inject(HttpClient);
   private zone = inject(NgZone);
-  private baseUrl = environment.apiBaseUrl;
+  private apiBase = environment.apiBase;
 
   private sse: EventSource | null = null;
   private tickSub = new Subject<Tick>();
@@ -36,13 +36,13 @@ export class MarketDataService {
   /** fetch selection of main instrument and options */
   getSelection(): Observable<{ mainInstrument: string; options: string[] } | null> {
     return this.http
-      .get<{ mainInstrument: string; options: string[] }>(`${this.baseUrl}/md/selection`)
+      .get<{ mainInstrument: string; options: string[] }>(`${this.apiBase}/md/selection`)
       .pipe(catchError(() => of(null)));
   }
 
   /** load historical candles */
   getCandles(key: string): Observable<Candle[]> {
-    return this.http.get<Candle[]>(`${this.baseUrl}/md/candles?instrumentKey=${encodeURIComponent(key)}&tf=1m&lookback=120`);
+    return this.http.get<Candle[]>(`${this.apiBase}/md/candles?instrumentKey=${encodeURIComponent(key)}&tf=1m&lookback=120`);
   }
 
   /** connect to the streaming endpoint for the selected instruments */
@@ -50,7 +50,7 @@ export class MarketDataService {
     this.disconnect();
     if (!keys.length) return;
     const params = keys.map(k => `instrumentKey=${encodeURIComponent(k)}`).join('&');
-    const url = `${this.baseUrl}/md/stream?${params}`;
+    const url = `${this.apiBase}/md/stream?${params}`;
     const open = () => {
       this.sse = new EventSource(url);
       this.connectionStatus.next(true);

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  apiBaseUrl: 'https://backendforautobot-production.up.railway.app'
+  apiBase: 'https://backendforautobot-production.up.railway.app'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: false,
-  apiBaseUrl: 'http://localhost:8081'
+  apiBase: 'http://localhost:8081'
 };


### PR DESCRIPTION
## Summary
- drop `apiBaseUrl` in favor of `apiBase` and point production to Railway backend
- update auth and market data services to use new API base

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No inputs were found in config file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adaf25f84c832fb47420fe76ac7742