### PR TITLE
feat: poll NIFTY LTP

### DIFF
--- a/src/app/pages/dashboard/dashboard.component.html
+++ b/src/app/pages/dashboard/dashboard.component.html
@@ -16,7 +16,7 @@
 
         <div class="panel price-panel">
           <div class="price-big">
-            {{ liveLtp !== null ? formatInr(liveLtp) : '—' }}
+            {{ ltp | number:'1.2-2' }}
           </div>
           <span class="chip-live" *ngIf="marketClosed">Market Closed</span>
           <div class="muted">24h <span class="rise">+0.68%</span></div>


### PR DESCRIPTION
## Summary
- poll backend /md/ltp endpoint every second for NIFTY futures
- bind dashboard to latest ltp and display numeric value

## Testing
- `npm test` *(fails: No inputs were found in config file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aef322ff74832fa3b4c68e6b1503d3