### PR TITLE
Display live NIFTY LTP via SSE on dashboard

### DIFF
--- a/src/app/pages/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/dashboard.component.ts
@@ -73,7 +73,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     }, 1000);
     this.fetchLtp();
     this.tickSub = this.marketData.listenTicks().subscribe(tick => {
-      if (tick.instrumentKey === this.mainInstrument) {
+      if (tick.instrumentKey === this.mainInstrument && tick.ltp != null) {
         this.nowLtp = tick.ltp;
       }
     });
@@ -116,8 +116,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
       error: err => {
         if (err.status === 503) {
           this.nowLtp = null;
-          const delay = 3000 + Math.random() * 2000;
-          setTimeout(() => this.fetchLtp(), delay);
+          setTimeout(() => this.fetchLtp(), 5000);
         }
       }
     });


### PR DESCRIPTION
## Summary
- show latest NIFTY FUT price in dashboard KPI
- update LTP from SSE ticks and retry HTTP fetch on failures

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No inputs were found in config file '/workspace/frontendfortheautobot/tsconfig.spec.json')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af02d3cdcc832fb81002089332fcba