### PR TITLE
feat: show live LTP on dashboard

### DIFF
--- a/src/app/pages/dashboard/dashboard.component.html
+++ b/src/app/pages/dashboard/dashboard.component.html
@@ -18,7 +18,9 @@
           <div class="price-value">
             {{ nowLtp === null ? '—' : (nowLtp | number:'1.2-2') }}
           </div>
-          <span class="chip-live" *ngIf="marketClosed">Market Closed</span>
+          <small *ngIf="ltpSource==='influx'">Last price · {{ ltpTs | date:'short' }}</small>
+          <small *ngIf="ltpSource==='live'">Live</small>
+          <span class="chip-live" *ngIf="marketOpen === false">Market Closed</span>
           <div class="muted">24h <span class="rise">+0.68%</span></div>
         </div>
 

--- a/src/app/services/market-data.service.ts
+++ b/src/app/services/market-data.service.ts
@@ -35,9 +35,13 @@ export class MarketDataService {
 
   /** fetch current LTP for the main instrument */
   getLtp() {
-    return this.http.get<{ instrumentKey: string; ltp: number; timestamp: string }>(
-      `${this.apiBase}/md/ltp`
-    );
+    return this.http.get<{
+      instrumentKey: string;
+      ltp: number;
+      timestamp: string;
+      marketOpen: boolean;
+      source: 'live' | 'influx';
+    }>(`${this.apiBase}/md/ltp`);
   }
 
   /** public observable to listen for tick updates */


### PR DESCRIPTION
## Summary
- extend market data service to expose source and market state for LTP
- show NIFTY futures last price or live price on dashboard
- retry LTP fetch on 204/503 to improve resilience

## Testing
- `npm test` *(fails: error TS18003: No inputs were found in config file)*

------
https://chatgpt.com/codex/tasks/task_e_68af1dfee11c832f9cadb2a35e00f7e4