### PR TITLE
Poll and display NIFTY FUTURE LTP

### DIFF
--- a/src/app/pages/dashboard/dashboard.component.css
+++ b/src/app/pages/dashboard/dashboard.component.css
@@ -33,6 +33,15 @@
   padding: 24px 16px;
 }
 
+.price-panel .dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  margin-right: 4px;
+}
+
 .metrics {
   display: grid;
   grid-template-columns: repeat(2, 1fr);

--- a/src/app/pages/dashboard/dashboard.component.html
+++ b/src/app/pages/dashboard/dashboard.component.html
@@ -18,8 +18,8 @@
           <div class="price-value">
             {{ nowLtp === null ? '—' : (nowLtp | number:'1.2-2') }}
           </div>
-          <small *ngIf="ltpSource==='influx'">Last price · {{ ltpTs | date:'short' }}</small>
-          <small *ngIf="ltpSource==='live'">Live</small>
+          <small *ngIf="ltpSource==='influx'">Last Saved · {{ ltpTs | date:'short' }}</small>
+          <small *ngIf="ltpSource==='live'"><span class="dot"></span>Live</small>
           <span class="chip-live" *ngIf="marketOpen === false">Market Closed</span>
           <div class="muted">24h <span class="rise">+0.68%</span></div>
         </div>

--- a/src/app/services/market-data.service.ts
+++ b/src/app/services/market-data.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NgZone, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { BehaviorSubject, Observable, Subject, catchError, of } from 'rxjs';
+import { BehaviorSubject, Observable, Subject, catchError, of, map } from 'rxjs';
 import { environment } from '../../environments/environment';
 
 export interface Candle {
@@ -33,15 +33,18 @@ export class MarketDataService {
   private delays = [1000, 2000, 5000, 10000];
   private delayIndex = 0;
 
-  /** fetch current LTP for the main instrument */
-  getLtp() {
-    return this.http.get<{
-      instrumentKey: string;
-      ltp: number;
-      timestamp: string;
-      marketOpen: boolean;
-      source: 'live' | 'influx';
-    }>(`${this.apiBase}/md/ltp`);
+  /** fetch current LTP for the given instrument */
+  getLtp(key: string) {
+    return this.http
+      .get<{
+        instrumentKey: string;
+        ltp: number;
+        ts: string;
+        source: 'live' | 'influx';
+      }>(`${this.apiBase}/md/ltp?instrumentKey=${encodeURIComponent(key)}`, {
+        observe: 'response',
+      })
+      .pipe(map(res => (res.status === 204 ? null : res.body || null)));
   }
 
   /** public observable to listen for tick updates */


### PR DESCRIPTION
## Summary
- Poll `/md/ltp` with the selected instrument key every 5 seconds and feed the dashboard price card
- Persist main instrument selection and show "Live" or "Last Saved" status in the card
- Add a minimal style for the live status dot

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No inputs were found in config file '/workspace/frontendfortheautobot/tsconfig.spec.json')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af24231cb8832f9a72d2ce78b46f00