### PR TITLE
Improve dashboard LTP handling

### DIFF
--- a/src/app/pages/dashboard/dashboard.component.css
+++ b/src/app/pages/dashboard/dashboard.component.css
@@ -38,8 +38,15 @@
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: var(--accent);
   margin-right: 4px;
+}
+
+.price-panel .dot-live {
+  background: var(--rise);
+}
+
+.price-panel .dot-influx {
+  background: var(--muted);
 }
 
 .metrics {

--- a/src/app/pages/dashboard/dashboard.component.html
+++ b/src/app/pages/dashboard/dashboard.component.html
@@ -18,8 +18,8 @@
           <div class="price-value">
             {{ nowLtp === null ? '—' : (nowLtp | number:'1.2-2') }}
           </div>
-          <small *ngIf="ltpSource==='influx'">Last Saved · {{ ltpTs | date:'short' }}</small>
-          <small *ngIf="ltpSource==='live'"><span class="dot"></span>Live</small>
+          <small *ngIf="ltpSource==='live'"><span class="dot dot-live"></span>Live</small>
+          <small *ngIf="ltpSource==='influx'"><span class="dot dot-influx"></span>Last saved</small>
           <span class="chip-live" *ngIf="marketOpen === false">Market Closed</span>
           <div class="muted">24h <span class="rise">+0.68%</span></div>
         </div>

--- a/src/app/pages/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/dashboard.component.ts
@@ -83,8 +83,11 @@ export class DashboardComponent implements OnInit, OnDestroy {
           if (sel?.mainInstrument) {
             localStorage.setItem('mainInstrumentKey', sel.mainInstrument);
             this.initializeInstrument(sel.mainInstrument);
+          } else {
+            this.initializeInstrument('NSE_FO|64103');
           }
         },
+        error: () => this.initializeInstrument('NSE_FO|64103'),
       });
     }
   }
@@ -145,7 +148,11 @@ export class DashboardComponent implements OnInit, OnDestroy {
           this.ltpSource = r.source;
           this.ltpTs = r.ts;
         },
-        error: () => {},
+        error: () => {
+          this.nowLtp = null;
+          this.ltpSource = undefined;
+          this.ltpTs = undefined;
+        },
       });
     };
     load();


### PR DESCRIPTION
## Summary
- show LTP as Live or Last saved with colored indicators
- default to NIFTY instrument and reset display on backend errors

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: TS18003: No inputs were found in config file)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68af31d3ef18832faac56125f360f069