### PR TITLE
feat: wire dashboard trade history to backend

### DIFF
--- a/src/app/models/trade-history.model.ts
+++ b/src/app/models/trade-history.model.ts
@@ -1,0 +1,13 @@
+export type OptionType = 'CE' | 'PE';
+
+export interface TradeRow {
+  ts: string;
+  instrumentKey: string;
+  optionType: OptionType;
+  strike: number;
+  ltp: number;
+  changePct: number;
+  qty: number;
+  oi: number;
+  txId: string;
+}

--- a/src/app/pages/dashboard/components/trade-history/trade-history.component.css
+++ b/src/app/pages/dashboard/components/trade-history/trade-history.component.css
@@ -44,3 +44,8 @@ tbody td {
   width: 20px;
   cursor: pointer;
 }
+
+.pill {
+  font-size: 11px;
+  padding: 2px 6px;
+}

--- a/src/app/pages/dashboard/components/trade-history/trade-history.component.html
+++ b/src/app/pages/dashboard/components/trade-history/trade-history.component.html
@@ -1,31 +1,42 @@
 <div class="history">
   <h3 class="muted">Trade History</h3>
-  <table class="panel">
-    <thead>
-      <tr>
-        <th>Time</th>
-        <th>Price</th>
-        <th>Change</th>
-        <th>Amount</th>
-        <th>Fee</th>
-        <th>Tx</th>
-        <th></th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr *ngFor="let r of rows">
-        <td>{{r.time}}</td>
-        <td>{{r.price}}</td>
-        <td>
-          <span class="delta" [class.up]="r.up" [class.down]="!r.up">
-            {{r.up ? '▲' : '▼'}} {{r.change}}
-          </span>
-        </td>
-        <td>{{r.amount}}</td>
-        <td>{{r.fee}}</td>
-        <td>{{r.hash}}</td>
-        <td class="kebab">⋮</td>
-      </tr>
-    </tbody>
-  </table>
+  <ng-container *ngIf="!loading; else loadingTpl">
+    <table class="panel" *ngIf="rows.length; else emptyTpl">
+      <thead>
+        <tr>
+          <th>Time</th>
+          <th>Price</th>
+          <th>Change</th>
+          <th>Amount</th>
+          <th>Fee</th>
+          <th>Tx</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let r of rows">
+          <td>{{ r.ts | date:'HH:mm:ss' }}</td>
+          <td>
+            <span class="pill" style="margin-right:4px" *ngIf="r.optionType">{{ r.optionType }} {{ r.strike }}</span>
+            {{ r.ltp | number:'1.2-2' }}
+          </td>
+          <td>
+            <span class="delta" [ngClass]="{up: r.changePct > 0, down: r.changePct < 0}">
+              {{ r.changePct > 0 ? '+' : '' }}{{ r.changePct.toFixed(2) }}%
+            </span>
+          </td>
+          <td>{{ r.qty }}</td>
+          <td>—</td>
+          <td title="{{ r.txId }}">{{ r.txId.slice(-6) }}</td>
+          <td class="kebab">⋮</td>
+        </tr>
+      </tbody>
+    </table>
+    <ng-template #emptyTpl>
+      <div class="panel" style="text-align:center; padding:24px">No trades yet</div>
+    </ng-template>
+  </ng-container>
+  <ng-template #loadingTpl>
+    <div class="panel" style="text-align:center; padding:24px">Loading...</div>
+  </ng-template>
 </div>

--- a/src/app/pages/dashboard/components/trade-history/trade-history.component.ts
+++ b/src/app/pages/dashboard/components/trade-history/trade-history.component.ts
@@ -1,15 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
-
-interface TradeRow {
-  time: string;
-  price: string;
-  change: string;
-  up: boolean;
-  amount: string;
-  fee: string;
-  hash: string;
-}
+import { TradeRow } from '../../../../models/trade-history.model';
 
 @Component({
   selector: 'app-trade-history',
@@ -20,4 +11,5 @@ interface TradeRow {
 })
 export class TradeHistoryComponent {
   @Input() rows: TradeRow[] = [];
+  @Input() loading = false;
 }

--- a/src/app/pages/dashboard/dashboard.component.css
+++ b/src/app/pages/dashboard/dashboard.component.css
@@ -28,6 +28,18 @@
   gap: 24px;
 }
 
+.trade-filters {
+  display: flex;
+  gap: 8px;
+  margin: 0 0 12px 4px;
+}
+
+.trade-filters .pill {
+  cursor: pointer;
+  font-size: 12px;
+  padding: 4px 8px;
+}
+
 .price-panel {
   text-align: center;
   padding: 24px 16px;

--- a/src/app/pages/dashboard/dashboard.component.html
+++ b/src/app/pages/dashboard/dashboard.component.html
@@ -36,7 +36,12 @@
 
       <div class="right-col">
         <app-candle-panel></app-candle-panel>
-        <app-trade-history [rows]="trades"></app-trade-history>
+        <div class="trade-filters">
+          <span class="pill" [class.muted]="filterSide!=='both'" (click)="setFilterSide('both')">All</span>
+          <span class="pill" [class.muted]="filterSide!=='CE'" (click)="setFilterSide('CE')">CE</span>
+          <span class="pill" [class.muted]="filterSide!=='PE'" (click)="setFilterSide('PE')">PE</span>
+        </div>
+        <app-trade-history [rows]="tradeRows" [loading]="loadingTrades"></app-trade-history>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add TradeRow model and backend service to fetch trade history
- display live CE/PE trades with filtering and polling on dashboard
- support SSE trade updates and styling for filter pills

## Testing
- `npm test` *(fails: No inputs were found in config file)*
- `npx tsc -p tsconfig.app.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68af5b819758832f9fab31e34932e9c7