### PR TITLE
feat: add sector CE/PE table

### DIFF
--- a/src/app/models/trade-row.ts
+++ b/src/app/models/trade-row.ts
@@ -1,12 +1,14 @@
 export type OptionSide = 'CE' | 'PE' | 'both';
+export type OptionType = 'CE' | 'PE';
+
 export interface TradeRow {
   ts: string;
   instrumentKey: string;
-  optionType: 'CE'|'PE';
+  optionType: OptionType;
   strike: number;
   ltp: number;
-  changePct: number;
-  qty: number;
-  oi: number|null;
+  changePct: number | null;
+  qty: number | null;
+  oi: number | null;
   txId: string;
 }

--- a/src/app/pages/dashboard/components/sector-table/sector-table.component.css
+++ b/src/app/pages/dashboard/components/sector-table/sector-table.component.css
@@ -1,0 +1,29 @@
+.sector-panel {
+  padding: 1rem;
+}
+
+.sector-panel .header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.pill-group { display:flex; gap:.5rem; }
+.pill-group button { padding:.25rem .6rem; border-radius:999px; background:#222a; color:#ddd; border:1px solid #444; }
+.pill-group button.active { background:#6d4cff; color:white; border-color:#6d4cff; }
+
+.mini-table { width:100%; border-collapse:collapse; }
+.mini-table th, .mini-table td { padding:.5rem .75rem; border-bottom:1px solid rgba(255,255,255,.06); }
+.mini-table .tx { opacity:.6; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+
+.up { color:#36d399; }
+.down { color:#f87272; }
+
+.empty, .loading { opacity:.7; padding:1rem; }
+
+.side { padding:0 .25rem; border-radius:4px; font-size:12px; }
+.side.ce { background:#6d4cff; color:#fff; }
+.side.pe { background:#444; color:#ddd; }
+
+.num { text-align:right; }

--- a/src/app/pages/dashboard/components/sector-table/sector-table.component.html
+++ b/src/app/pages/dashboard/components/sector-table/sector-table.component.html
@@ -1,0 +1,45 @@
+<div class="panel sector-panel">
+  <div class="header">
+    <h3>Sector CE/PE</h3>
+    <div class="pill-group">
+      <button [class.active]="selectedSide==='both'" (click)="onSideChange('both')">All</button>
+      <button [class.active]="selectedSide==='CE'" (click)="onSideChange('CE')">CE</button>
+      <button [class.active]="selectedSide==='PE'" (click)="onSideChange('PE')">PE</button>
+    </div>
+  </div>
+  <div class="loading" *ngIf="loading">Loading…</div>
+  <table class="mini-table" *ngIf="rows.length; else emptyTpl">
+    <thead>
+      <tr>
+        <th>Time</th>
+        <th>Side</th>
+        <th class="num">Strike</th>
+        <th class="num">LTP</th>
+        <th>Change</th>
+        <th class="num">Qty</th>
+        <th class="num">OI</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let r of rows; trackBy: trackTx">
+        <td>{{ r.ts | date:'HH:mm:ss' }}</td>
+        <td><span class="side" [class.ce]="r.optionType==='CE'" [class.pe]="r.optionType==='PE'">{{ r.optionType }}</span></td>
+        <td class="num">{{ r.strike }}</td>
+        <td class="num">{{ r.ltp | number:'1.2-2' }}</td>
+        <td>
+          <ng-container *ngIf="r.changePct !== null; else dash">
+            <span [class.up]="r.changePct>0" [class.down]="r.changePct<0">
+              {{ r.changePct>0 ? '+' : ''}}{{ (r.changePct*100) | number:'1.2-2' }}%
+            </span>
+          </ng-container>
+          <ng-template #dash>—</ng-template>
+        </td>
+        <td class="num">{{ r.qty === null ? '—' : r.qty }}</td>
+        <td class="num">{{ r.oi === null ? '—' : r.oi }}</td>
+      </tr>
+    </tbody>
+  </table>
+  <ng-template #emptyTpl>
+    <div class="empty">No trades yet</div>
+  </ng-template>
+</div>

--- a/src/app/pages/dashboard/components/sector-table/sector-table.component.ts
+++ b/src/app/pages/dashboard/components/sector-table/sector-table.component.ts
@@ -1,0 +1,61 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { interval, Subscription } from 'rxjs';
+import { finalize } from 'rxjs/operators';
+import { MarketDataService } from '../../../../services/market-data.service';
+import { TradeRow } from '../../../../models/trade-row';
+
+@Component({
+  selector: 'app-sector-table',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './sector-table.component.html',
+  styleUrls: ['./sector-table.component.css']
+})
+export class SectorTableComponent implements OnInit, OnDestroy {
+  selectedSide: 'both' | 'CE' | 'PE' = 'both';
+  limit = 50;
+  rows: TradeRow[] = [];
+  loading = true;
+  lastLoadedAt?: string;
+  private timerSub?: Subscription;
+
+  constructor(private marketData: MarketDataService) {}
+
+  ngOnInit() {
+    this.load();
+    this.timerSub = interval(10000).subscribe(() => this.load());
+  }
+
+  ngOnDestroy() {
+    this.timerSub?.unsubscribe();
+  }
+
+  load() {
+    if (!this.rows.length) {
+      this.loading = true;
+    }
+    this.marketData
+      .getSectorTrades(this.limit, this.selectedSide)
+      .pipe(finalize(() => (this.loading = false)))
+      .subscribe({
+        next: rows => {
+          this.rows = rows ?? [];
+          this.lastLoadedAt = new Date().toISOString();
+        },
+        error: () => {
+          this.rows = [];
+        }
+      });
+  }
+
+  onSideChange(side: 'both' | 'CE' | 'PE') {
+    if (this.selectedSide !== side) {
+      this.selectedSide = side;
+      this.rows = [];
+      this.load();
+    }
+  }
+
+  trackTx = (_: number, r: TradeRow) => r.txId;
+}

--- a/src/app/pages/dashboard/dashboard.component.css
+++ b/src/app/pages/dashboard/dashboard.component.css
@@ -98,26 +98,6 @@
   margin-left: 6px;
 }
 
-.sector-panel {
-  padding: 1rem;
-}
-
-.sector-panel .header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 0.5rem;
-}
-
-.mini-table { width:100%; border-collapse:collapse; }
-.mini-table th, .mini-table td { padding:.5rem .75rem; border-bottom:1px solid rgba(255,255,255,.06); }
-.mini-table .tx { opacity:.6; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
-.pill-group { display:flex; gap:.5rem; }
-.pill-group button { padding:.25rem .6rem; border-radius:999px; background:#222a; color:#ddd; border:1px solid #444; }
-.pill-group button.active { background:#6d4cff; color:white; border-color:#6d4cff; }
-.up { color:#36d399; }
-.down { color:#f87272; }
-.empty, .loading { opacity:.7; padding:1rem; }
 
 @media (max-width: 1200px) {
   .dashboard {

--- a/src/app/pages/dashboard/dashboard.component.html
+++ b/src/app/pages/dashboard/dashboard.component.html
@@ -36,48 +36,7 @@
 
       <div class="right-col">
         <app-candle-panel></app-candle-panel>
-        <div class="panel sector-panel">
-          <div class="header">
-            <h3>Sector CE/PE</h3>
-            <div class="pill-group">
-              <button [class.active]="sectorSide==='both'" (click)="loadSector('both')">All</button>
-              <button [class.active]="sectorSide==='CE'" (click)="loadSector('CE')">CE</button>
-              <button [class.active]="sectorSide==='PE'" (click)="loadSector('PE')">PE</button>
-            </div>
-          </div>
-          <table class="mini-table" *ngIf="!sectorLoading && sectorRows?.length; else sectorEmpty">
-            <thead>
-              <tr>
-                <th>Time</th>
-                <th>Symbol</th>
-                <th>Price</th>
-                <th>Change</th>
-                <th>Qty</th>
-                <th>OI</th>
-                <th>Tx</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr *ngFor="let r of sectorRows; trackBy: trackTx">
-                <td>{{ r.ts | date:'HH:mm:ss' }}</td>
-                <td>{{ r.optionType }} {{ r.strike }}</td>
-                <td>{{ r.ltp | number:'1.2-2' }}</td>
-                <td>
-                  <span [class.up]="r.changePct>0" [class.down]="r.changePct<0">
-                    {{ (r.changePct*100) | number:'1.2-2' }}%
-                  </span>
-                </td>
-                <td>{{ r.qty }}</td>
-                <td>{{ r.oi ?? '—' }}</td>
-                <td class="tx">{{ r.txId }}</td>
-              </tr>
-            </tbody>
-          </table>
-          <ng-template #sectorEmpty>
-            <div class="empty" *ngIf="!sectorLoading">No trades yet</div>
-            <div class="loading" *ngIf="sectorLoading">Loading…</div>
-          </ng-template>
-        </div>
+        <app-sector-table></app-sector-table>
       </div>
     </div>
   </div>

--- a/src/app/pages/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/dashboard.component.ts
@@ -7,11 +7,11 @@ import { MetricCardComponent } from './components/metric-card/metric-card.compon
 import { CandlePanelComponent } from './components/candle-panel/candle-panel.component';
 import { DonutScoreComponent } from './components/donut-score/donut-score.component';
 import { TrustBarComponent } from './components/trust-bar/trust-bar.component';
+import { SectorTableComponent } from './components/sector-table/sector-table.component';
 import { AuthService } from '../../services/auth.service';
 import { formatCountdown } from '../../utils/time';
 import { MarketDataService } from '../../services/market-data.service';
 import { Subscription } from 'rxjs';
-import { OptionSide, TradeRow } from '../../models/trade-row';
 
 @Component({
   selector: 'app-dashboard',
@@ -24,7 +24,8 @@ import { OptionSide, TradeRow } from '../../models/trade-row';
     MetricCardComponent,
     CandlePanelComponent,
     DonutScoreComponent,
-    TrustBarComponent
+    TrustBarComponent,
+    SectorTableComponent
   ],
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.css']
@@ -36,11 +37,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
     { title: "Open Interest ('000)", value: '120.6' },
     { title: "Lots Traded ('000)", value: '271.35' }
   ];
-
-  sectorRows: TradeRow[] = [];
-  sectorLoading = false;
-  sectorSide: OptionSide = 'both';
-  sectorTimer?: any;
 
   connected = false;
   expiresAt: string | null = null;
@@ -85,8 +81,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
         error: () => this.initializeInstrument('NSE_FO|64103'),
       });
     }
-    this.loadSector('both');
-    this.startSectorPolling();
   }
 
   ngOnDestroy() {
@@ -94,7 +88,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
     clearInterval(this.countdown);
     clearInterval(this.ltpInterval);
     this.tickSub?.unsubscribe();
-    this.clearSectorPolling();
   }
 
   private checkStatus() {
@@ -157,27 +150,5 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.ltpInterval = setInterval(load, 5000);
   }
 
-  loadSector(side: OptionSide = this.sectorSide) {
-    this.sectorSide = side;
-    this.sectorLoading = true;
-    this.marketData.getSectorTrades(side, 50).subscribe(rows => {
-      this.sectorRows = rows;
-      this.sectorLoading = false;
-    });
-  }
-
-  startSectorPolling() {
-    this.clearSectorPolling();
-    this.sectorTimer = setInterval(() => this.loadSector(this.sectorSide), 10000);
-  }
-
-  clearSectorPolling() {
-    if (this.sectorTimer) {
-      clearInterval(this.sectorTimer);
-      this.sectorTimer = undefined;
-    }
-  }
-
-  trackTx = (_: number, r: TradeRow) => r.txId;
 
 }

--- a/src/app/services/market-data.service.ts
+++ b/src/app/services/market-data.service.ts
@@ -2,7 +2,7 @@ import { Injectable, NgZone, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { BehaviorSubject, Observable, Subject, catchError, of, map } from 'rxjs';
 import { environment } from '../../environments/environment';
-import { OptionSide, TradeRow } from '../models/trade-row';
+import { TradeRow } from '../models/trade-row';
 
 export interface Candle {
   time: string; // ISO timestamp of minute start
@@ -72,13 +72,9 @@ export class MarketDataService {
     return this.http.get<Candle[]>(`${this.apiBase}/md/candles?instrumentKey=${encodeURIComponent(key)}&tf=1m&lookback=120`);
   }
 
-  getSectorTrades(side: OptionSide = 'both', limit = 50) {
-    const params = new HttpParams()
-      .set('side', side)
-      .set('limit', String(limit));
-    return this.http
-      .get<TradeRow[]>(`${environment.apiBase}/md/sector-trades`, { params })
-      .pipe(catchError(() => of([])));
+  getSectorTrades(limit = 50, side: 'both' | 'CE' | 'PE' = 'both'): Observable<TradeRow[]> {
+    const params = new HttpParams().set('limit', limit).set('side', side);
+    return this.http.get<TradeRow[]>(`${environment.apiBase}/md/sector-trades`, { params });
   }
 
   /** connect to the streaming endpoint for the selected instruments */


### PR DESCRIPTION
## Summary
- wire sector trades API via `getSectorTrades`
- introduce auto-refreshing Sector CE/PE table with filters
- integrate widget into dashboard

## Testing
- `npm test -- --watch=false` *(fails: No inputs were found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af6cf98044832fac9e9dae51259abc