### PR TITLE
feat: add sector CE/PE trades panel

### DIFF
--- a/src/app/pages/dashboard/dashboard.component.html
+++ b/src/app/pages/dashboard/dashboard.component.html
@@ -36,7 +36,7 @@
 
       <div class="right-col">
         <app-candle-panel></app-candle-panel>
-        <app-sector-table></app-sector-table>
+        <app-sector-trades></app-sector-trades>
       </div>
     </div>
   </div>

--- a/src/app/pages/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/dashboard.component.ts
@@ -7,7 +7,7 @@ import { MetricCardComponent } from './components/metric-card/metric-card.compon
 import { CandlePanelComponent } from './components/candle-panel/candle-panel.component';
 import { DonutScoreComponent } from './components/donut-score/donut-score.component';
 import { TrustBarComponent } from './components/trust-bar/trust-bar.component';
-import { SectorTableComponent } from './components/sector-table/sector-table.component';
+import { SectorTradesComponent } from './sector-trades.component';
 import { AuthService } from '../../services/auth.service';
 import { formatCountdown } from '../../utils/time';
 import { MarketDataService } from '../../services/market-data.service';
@@ -25,7 +25,7 @@ import { Subscription } from 'rxjs';
     CandlePanelComponent,
     DonutScoreComponent,
     TrustBarComponent,
-    SectorTableComponent
+    SectorTradesComponent
   ],
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.css']

--- a/src/app/pages/dashboard/sector-trades.component.css
+++ b/src/app/pages/dashboard/sector-trades.component.css
@@ -1,0 +1,101 @@
+:host {
+  display: block;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.pill-group {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.seg-pill {
+  padding: 4px 10px;
+  border-radius: 9999px;
+  cursor: pointer;
+  border: 1px solid #444;
+  background: #222a;
+  color: #ddd;
+  font-size: 12px;
+}
+
+.seg-pill.active {
+  background: rgba(120, 80, 255, 0.25);
+  border: 1px solid rgba(120, 80, 255, 0.6);
+  color: #fff;
+}
+
+.src-badge {
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 8px;
+  margin-left: 8px;
+}
+
+.src-live {
+  background: rgba(16, 185, 129, 0.15);
+  color: #10b981;
+}
+
+.src-hist {
+  background: rgba(156, 163, 175, 0.15);
+  color: #9ca3af;
+}
+
+.table-container {
+  height: 360px;
+  overflow: auto;
+}
+
+.mini-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.mini-table th,
+.mini-table td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  white-space: nowrap;
+}
+
+.num {
+  text-align: right;
+}
+
+.side-chip {
+  padding: 0 4px;
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+.side-chip.ce {
+  background: #6d4cff;
+  color: #fff;
+}
+
+.side-chip.pe {
+  background: #444;
+  color: #ddd;
+}
+
+.up {
+  color: #36d399;
+}
+
+.down {
+  color: #f87272;
+}
+
+.loading,
+.error,
+.empty {
+  padding: 1rem;
+  opacity: 0.7;
+}
+

--- a/src/app/pages/dashboard/sector-trades.component.html
+++ b/src/app/pages/dashboard/sector-trades.component.html
@@ -1,0 +1,48 @@
+<div class="panel sector-trades">
+  <div class="header">
+    <h3>Sector CE/PE <span *ngIf="source" class="src-badge" [ngClass]="{'src-live': source==='live', 'src-hist': source!=='live'}">{{ source==='live' ? 'LIVE' : 'HISTORY' }}</span></h3>
+    <div class="pill-group">
+      <div class="seg-pill" [class.active]="side==='both'" (click)="setSide('both')">All</div>
+      <div class="seg-pill" [class.active]="side==='CE'" (click)="setSide('CE')">CE</div>
+      <div class="seg-pill" [class.active]="side==='PE'" (click)="setSide('PE')">PE</div>
+    </div>
+  </div>
+
+  <div class="table-container">
+    <div *ngIf="loading" class="loading">Loading…</div>
+    <div *ngIf="error" class="error">{{ error }}</div>
+    <table *ngIf="!loading && !error && rows.length" class="mini-table">
+      <thead>
+        <tr>
+          <th>Time</th>
+          <th>Side</th>
+          <th class="num">Strike</th>
+          <th class="num">LTP</th>
+          <th>Change</th>
+          <th class="num">Qty</th>
+          <th class="num">OI</th>
+          <th class="num">IV</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let r of rows; trackBy: trackByTs">
+          <td>{{ r.ts | date:'HH:mm:ss' }}</td>
+          <td><span class="side-chip" [class.ce]="r.optionType==='CE'" [class.pe]="r.optionType==='PE'">{{ r.optionType }}</span></td>
+          <td class="num">{{ r.strike }}</td>
+          <td class="num">{{ r.ltp | number:'1.2-2' }}</td>
+          <td>
+            <ng-container *ngIf="r.changePct != null; else dash">
+              <span [class.up]="r.changePct > 0" [class.down]="r.changePct < 0">{{ r.changePct > 0 ? '+' : ''}}{{ (r.changePct * 100) | number:'1.2-2' }}%</span>
+            </ng-container>
+            <ng-template #dash>—</ng-template>
+          </td>
+          <td class="num">{{ r.qty == null ? '—' : r.qty }}</td>
+          <td class="num">{{ r.oi == null ? '—' : r.oi }}</td>
+          <td class="num">{{ r.iv == null ? '—' : (r.iv | number:'1.2-2') }}</td>
+        </tr>
+      </tbody>
+    </table>
+    <div *ngIf="!loading && !error && !rows.length" class="empty">No trades yet</div>
+  </div>
+</div>
+

--- a/src/app/pages/dashboard/sector-trades.component.ts
+++ b/src/app/pages/dashboard/sector-trades.component.ts
@@ -1,0 +1,57 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { MarketDataService, SectorTradeRow } from '../../services/market-data.service';
+
+type Side = 'both' | 'CE' | 'PE';
+
+@Component({
+  selector: 'app-sector-trades',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './sector-trades.component.html',
+  styleUrls: ['./sector-trades.component.css']
+})
+export class SectorTradesComponent implements OnInit {
+  side: Side = 'both';
+  rows: SectorTradeRow[] = [];
+  loading = false;
+  error?: string;
+  source?: 'live' | 'influx';
+
+  constructor(private marketData: MarketDataService) {}
+
+  ngOnInit() {
+    const stored = localStorage.getItem('sector.side') as Side | null;
+    if (stored === 'CE' || stored === 'PE' || stored === 'both') {
+      this.side = stored;
+    }
+    this.fetch(this.side);
+  }
+
+  setSide(side: Side) {
+    if (side === this.side) return;
+    this.side = side;
+    localStorage.setItem('sector.side', side);
+    this.fetch(side);
+  }
+
+  fetch(side: Side) {
+    this.loading = true;
+    this.error = undefined;
+    this.marketData.getSectorTrades(side).subscribe({
+      next: res => {
+        this.rows = res.rows;
+        this.source = res.source;
+        this.loading = false;
+      },
+      error: () => {
+        this.error = 'Failed to load';
+        this.rows = [];
+        this.loading = false;
+      }
+    });
+  }
+
+  trackByTs = (_: number, r: SectorTradeRow) => r.ts + r.optionType + r.strike;
+}
+


### PR DESCRIPTION
## Summary
- add market data service for sector trades with source detection
- implement sector CE/PE trades component with side filters and scrolling table
- wire new component into dashboard

## Testing
- `npm test -- --watch=false` *(fails: error TS18003: No inputs were found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b09ed6fd64832f9bbd8e02f0075431