### PR TITLE
feat: poll sector trades every 5s

### DIFF
--- a/src/app/pages/dashboard/sector-trades.component.ts
+++ b/src/app/pages/dashboard/sector-trades.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { interval, Subscription } from 'rxjs';
 import { MarketDataService, SectorTradeRow } from '../../services/market-data.service';
 
 type Side = 'both' | 'CE' | 'PE';
@@ -11,12 +12,14 @@ type Side = 'both' | 'CE' | 'PE';
   templateUrl: './sector-trades.component.html',
   styleUrls: ['./sector-trades.component.css']
 })
-export class SectorTradesComponent implements OnInit {
+export class SectorTradesComponent implements OnInit, OnDestroy {
   side: Side = 'both';
   rows: SectorTradeRow[] = [];
   loading = false;
   error?: string;
   source?: 'live' | 'influx';
+
+  private timer?: Subscription;
 
   constructor(private marketData: MarketDataService) {}
 
@@ -26,6 +29,11 @@ export class SectorTradesComponent implements OnInit {
       this.side = stored;
     }
     this.fetch(this.side);
+    this.timer = interval(5000).subscribe(() => this.fetch(this.side));
+  }
+
+  ngOnDestroy() {
+    this.timer?.unsubscribe();
   }
 
   setSide(side: Side) {


### PR DESCRIPTION
## Summary
- poll sector trades API every 5 seconds to keep Sector CE/PE table updated

## Testing
- `npm test` *(fails: TS18003 No inputs were found in config file /workspace/frontendfortheautobot/tsconfig.spec.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b12f77721c832fb6c6eca42d6ca16c