### PR TITLE
Add watchlist and chart flow

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,0 +1,70 @@
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 32px;
+  background: rgba(17, 19, 30, 0.85);
+  backdrop-filter: blur(12px);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+}
+
+.brand {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--accent);
+  text-decoration: none;
+  letter-spacing: 0.04em;
+}
+
+.nav-links {
+  display: flex;
+  gap: 18px;
+  align-items: center;
+}
+
+.nav-links a {
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 500;
+  opacity: 0.75;
+  transition: opacity 0.2s ease, color 0.2s ease;
+}
+
+.nav-links a:hover,
+.nav-links a.active {
+  opacity: 1;
+  color: var(--accent-2);
+}
+
+.app-main {
+  flex: 1;
+  padding: 24px;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+}
+
+@media (max-width: 768px) {
+  .app-header {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .nav-links {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .app-main {
+    padding: 16px;
+  }
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,10 +1,28 @@
 import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet],
-  template: `<router-outlet></router-outlet>`,
+  imports: [CommonModule, RouterOutlet, RouterLink, RouterLinkActive],
+  styleUrls: ['./app.component.css'],
+  template: `
+    <div class="app-shell">
+      <header class="app-header">
+        <a class="brand" routerLink="/watchlist">Autobot</a>
+        <nav class="nav-links">
+          <a routerLink="/search" routerLinkActive="active">Search</a>
+          <a routerLink="/watchlist" routerLinkActive="active">Watchlist</a>
+          <a routerLink="/chart/NSE_EQ%7CAXISBANK" routerLinkActive="active">Sample Chart</a>
+          <a routerLink="/dashboard" routerLinkActive="active">Dashboard</a>
+          <a routerLink="/login" routerLinkActive="active">Login</a>
+        </nav>
+      </header>
+      <main class="app-main">
+        <router-outlet></router-outlet>
+      </main>
+    </div>
+  `,
 })
 export class AppComponent {}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,9 +2,15 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { DashboardComponent } from './pages/dashboard/dashboard.component';
 import { LoginComponent } from './pages/login/login.component';
+import { SearchComponent } from './pages/search/search.component';
+import { WatchlistComponent } from './pages/watchlist/watchlist.component';
+import { ChartComponent } from './pages/chart/chart.component';
 
 export const routes: Routes = [
-  { path: '', redirectTo: '/login', pathMatch: 'full' },
+  { path: '', redirectTo: '/watchlist', pathMatch: 'full' },
+  { path: 'search', component: SearchComponent },
+  { path: 'watchlist', component: WatchlistComponent },
+  { path: 'chart/:instrumentKey', component: ChartComponent },
   { path: 'dashboard', component: DashboardComponent },
   { path: 'login', component: LoginComponent }
   // (optional) add other routes

--- a/src/app/pages/chart/chart.component.css
+++ b/src/app/pages/chart/chart.component.css
@@ -1,0 +1,140 @@
+.chart-page {
+  width: min(960px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.chart-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.chart-header h2 {
+  margin: 0;
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+}
+
+.status .dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.25);
+}
+
+.status .dot.connected {
+  background: var(--rise);
+}
+
+.status .dot.connecting {
+  background: var(--accent-2);
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.tf-options {
+  display: inline-flex;
+  gap: 8px;
+}
+
+.tf-options button {
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: none;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.tf-options button.active {
+  background: var(--accent);
+}
+
+.history {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--muted);
+}
+
+.error {
+  color: var(--fall);
+}
+
+.chart-area {
+  width: 100%;
+  overflow-x: auto;
+  background: rgba(35, 41, 58, 0.8);
+  border-radius: 20px;
+  padding: 18px;
+}
+
+.chart-area svg {
+  width: 100%;
+  height: 280px;
+}
+
+.info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.panel {
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(35, 41, 58, 0.85);
+}
+
+.panel h3 {
+  margin-top: 0;
+}
+
+.orderbook table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.orderbook th,
+.orderbook td {
+  padding: 6px 4px;
+  text-align: right;
+}
+
+.orderbook th {
+  color: var(--muted);
+  font-weight: 400;
+}
+
+.spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.2);
+  border-top-color: var(--accent-2);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/app/pages/chart/chart.component.html
+++ b/src/app/pages/chart/chart.component.html
@@ -1,0 +1,88 @@
+<div class="chart-page shell" *ngIf="instrumentKey() as key">
+  <header class="chart-header">
+    <div>
+      <h2>{{ instrumentDisplay() }}</h2>
+      <p class="subtitle">{{ key }}</p>
+    </div>
+    <div class="status">
+      <span class="dot" [class.connected]="wsState() === 'connected'" [class.connecting]="wsState() === 'connecting'"></span>
+      <span>{{ wsState() | titlecase }}</span>
+    </div>
+  </header>
+  <div class="toolbar">
+    <label>Timeframe</label>
+    <div class="tf-options">
+      <button
+        *ngFor="let tf of timeframeOptions"
+        type="button"
+        [class.active]="timeframe() === tf"
+        (click)="changeTimeframe(tf)"
+      >
+        {{ tf }}
+      </button>
+    </div>
+  </div>
+  <div class="history" *ngIf="historyLoading()">
+    <span class="spinner"></span>
+    <span>Loading history…</span>
+  </div>
+  <p class="error" *ngIf="historyError()">{{ historyError() }}</p>
+  <div class="chart-area" *ngIf="!historyLoading() && candleShapes().length">
+    <svg [attr.viewBox]="'0 0 ' + chartWidth() + ' ' + chartHeight()">
+      <ng-container *ngFor="let candle of candleShapes()">
+        <line
+          [attr.x1]="candle.x + candle.width / 2"
+          [attr.x2]="candle.x + candle.width / 2"
+          [attr.y1]="candle.wickTop"
+          [attr.y2]="candle.wickBottom"
+          stroke="#94a3b8"
+          stroke-width="1"
+        ></line>
+        <rect
+          [attr.x]="candle.x"
+          [attr.y]="candle.bodyTop"
+          [attr.width]="candle.width"
+          [attr.height]="candle.bodyHeight"
+          [attr.fill]="candle.color"
+          rx="3"
+        ></rect>
+      </ng-container>
+    </svg>
+  </div>
+  <section class="info-grid">
+    <div class="panel info">
+      <h3>Last tick</h3>
+      <p *ngIf="latestTick(); else noTick">
+        Price: <strong>{{ latestTick()?.ltp | number: '1.2-2' }}</strong>
+        <span class="muted">&#64; {{ latestTick()?.ts | date: 'mediumTime' }}</span>
+      </p>
+      <ng-template #noTick>
+        <p class="muted">Waiting for live data…</p>
+      </ng-template>
+    </div>
+    <div class="panel orderbook">
+      <h3>Top of book</h3>
+      <table *ngIf="bidAskLevels()?.length; else emptyBook">
+        <thead>
+          <tr>
+            <th>Bid</th>
+            <th>Qty</th>
+            <th>Ask</th>
+            <th>Qty</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let lvl of bidAskLevels()">
+            <td class="rise">{{ lvl.bidP | number: '1.2-2' }}</td>
+            <td>{{ lvl.bidQ }}</td>
+            <td class="fall">{{ lvl.askP | number: '1.2-2' }}</td>
+            <td>{{ lvl.askQ }}</td>
+          </tr>
+        </tbody>
+      </table>
+      <ng-template #emptyBook>
+        <p class="muted">Bid/ask not available.</p>
+      </ng-template>
+    </div>
+  </section>
+</div>

--- a/src/app/pages/chart/chart.component.ts
+++ b/src/app/pages/chart/chart.component.ts
@@ -1,0 +1,201 @@
+import { Component, OnDestroy, OnInit, computed, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
+import { Subscription, timer } from 'rxjs';
+import { retry } from 'rxjs/operators';
+import { MarketService, Candle, Tick, Timeframe, WsConnectionState } from '../../services/market.service';
+import { WatchlistService } from '../../services/watchlist.service';
+
+interface CandleShape {
+  x: number;
+  width: number;
+  bodyTop: number;
+  bodyHeight: number;
+  wickTop: number;
+  wickBottom: number;
+  color: string;
+}
+
+@Component({
+  selector: 'app-chart',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './chart.component.html',
+  styleUrls: ['./chart.component.css']
+})
+export class ChartComponent implements OnInit, OnDestroy {
+  instrumentKey = signal<string>('');
+  timeframe = signal<Timeframe>('1m');
+  historyLoading = signal(false);
+  historyError = signal<string | null>(null);
+  candles = signal<Candle[]>([]);
+  candleShapes = signal<CandleShape[]>([]);
+  chartWidth = signal(720);
+  chartHeight = signal(280);
+  latestTick = signal<Tick | null>(null);
+  bidAskLevels = signal<{ bidP: number; bidQ: number; askP: number; askQ: number }[]>([]);
+  wsState = signal<WsConnectionState>('disconnected');
+
+  readonly timeframeOptions: Timeframe[] = ['1s', '1m', '5m'];
+
+  private wsSub?: Subscription;
+  private routeSub?: Subscription;
+  private stateSub?: Subscription;
+
+  constructor(
+    private route: ActivatedRoute,
+    private market: MarketService,
+    private watchlist: WatchlistService
+  ) {}
+
+  ngOnInit(): void {
+    this.stateSub = this.market.connectionState$.subscribe(state => this.wsState.set(state));
+    this.routeSub = this.route.paramMap.subscribe(params => {
+      const key = params.get('instrumentKey');
+      if (!key) {
+        return;
+      }
+      this.instrumentKey.set(key);
+      this.loadHistory();
+      this.connectSocket();
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.wsSub?.unsubscribe();
+    this.market.disconnect();
+    this.routeSub?.unsubscribe();
+    this.stateSub?.unsubscribe();
+  }
+
+  readonly instrumentDisplay = computed(() => {
+    const key = this.instrumentKey();
+    const match = this.watchlist.getAll().find(entry => entry.instrumentKey === key);
+    return match?.display ?? key;
+  });
+
+  changeTimeframe(tf: Timeframe) {
+    if (this.timeframe() === tf) return;
+    this.timeframe.set(tf);
+    this.loadHistory();
+  }
+
+  private loadHistory() {
+    const key = this.instrumentKey();
+    if (!key) return;
+    this.historyLoading.set(true);
+    this.historyError.set(null);
+    this.market.history(key, this.timeframe(), 300).subscribe({
+      next: candles => {
+        this.candles.set(candles);
+        this.historyLoading.set(false);
+        this.recomputeShapes();
+      },
+      error: () => {
+        this.historyLoading.set(false);
+        this.historyError.set('Failed to load history.');
+        this.candles.set([]);
+        this.candleShapes.set([]);
+      }
+    });
+  }
+
+  private connectSocket() {
+    const key = this.instrumentKey();
+    if (!key) return;
+    this.wsSub?.unsubscribe();
+    const subject = this.market.connectWs([key]);
+    this.wsSub = subject
+      .pipe(
+        retry({
+          delay: (_, retryCount) => {
+            const delayMs = Math.min(1000 * Math.pow(2, retryCount - 1), 20000);
+            return timer(delayMs);
+          },
+        })
+      )
+      .subscribe({
+        next: tick => this.processTick(tick),
+        error: () => this.wsState.set('disconnected')
+      });
+  }
+
+  private processTick(tick: Tick) {
+    if (!tick || tick.instrumentKey !== this.instrumentKey()) return;
+    this.latestTick.set(tick);
+    this.bidAskLevels.set((tick.bidAsk ?? []).slice(0, 5));
+    if (tick.ltp == null) return;
+    const timeframeMs = this.timeframeToMs(this.timeframe());
+    const bucket = Math.floor(tick.ts / timeframeMs) * timeframeMs;
+    const candles = [...this.candles()];
+    let candle = candles[candles.length - 1];
+    if (!candle || candle.ts !== bucket) {
+      candle = { ts: bucket, open: tick.ltp, high: tick.ltp, low: tick.ltp, close: tick.ltp, volume: tick.ltq ?? 0 };
+      candles.push(candle);
+      if (candles.length > 400) {
+        candles.splice(0, candles.length - 400);
+      }
+    } else {
+      candle.close = tick.ltp;
+      candle.high = Math.max(candle.high, tick.ltp);
+      candle.low = Math.min(candle.low, tick.ltp);
+      if (tick.ltq != null) {
+        candle.volume = (candle.volume ?? 0) + tick.ltq;
+      }
+    }
+    this.candles.set(candles);
+    this.recomputeShapes();
+  }
+
+  private recomputeShapes() {
+    const candles = this.candles();
+    if (!candles.length) {
+      this.candleShapes.set([]);
+      return;
+    }
+    const highs = candles.map(c => c.high ?? c.close ?? c.open);
+    const lows = candles.map(c => c.low ?? c.close ?? c.open);
+    const max = Math.max(...highs);
+    const min = Math.min(...lows);
+    const height = 260;
+    const widthPer = 12;
+    const gap = 6;
+    const viewWidth = candles.length * (widthPer + gap) + gap;
+    this.chartWidth.set(Math.max(viewWidth, 320));
+    this.chartHeight.set(height + 20);
+    const span = max - min || 1;
+    const scale = (value: number) => {
+      return height - ((value - min) / span) * height + 10;
+    };
+    const shapes: CandleShape[] = candles.map((candle, index) => {
+      const center = gap + index * (widthPer + gap) + widthPer / 2;
+      const openY = scale(candle.open);
+      const closeY = scale(candle.close);
+      const highY = scale(candle.high);
+      const lowY = scale(candle.low);
+      const bodyTop = Math.min(openY, closeY);
+      const bodyHeight = Math.max(Math.abs(closeY - openY), 1);
+      return {
+        x: center - widthPer / 2,
+        width: widthPer,
+        bodyTop,
+        bodyHeight,
+        wickTop: highY,
+        wickBottom: lowY,
+        color: candle.close >= candle.open ? '#21c55d' : '#ef4444'
+      };
+    });
+    this.candleShapes.set(shapes);
+  }
+
+  private timeframeToMs(tf: Timeframe) {
+    switch (tf) {
+      case '1s':
+        return 1000;
+      case '5m':
+        return 5 * 60 * 1000;
+      default:
+        return 60 * 1000;
+    }
+  }
+}

--- a/src/app/pages/search/search.component.css
+++ b/src/app/pages/search/search.component.css
@@ -1,0 +1,118 @@
+.search-shell {
+  width: min(960px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.search-form {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.search-form input {
+  flex: 1;
+  padding: 12px 16px;
+  border-radius: 999px;
+  border: none;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+  font-size: 16px;
+  outline: none;
+}
+
+.search-form input:focus {
+  box-shadow: 0 0 0 2px rgba(124, 77, 255, 0.35);
+}
+
+.results {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.result {
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(35, 41, 58, 0.85);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 18px;
+}
+
+.result .display {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0 0 6px;
+}
+
+.result .meta {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+button.pill[disabled] {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.ghost {
+  padding: 10px 16px;
+  border-radius: 999px;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text);
+  text-decoration: none;
+  font-size: 14px;
+}
+
+.hint {
+  color: var(--muted);
+  margin: 0;
+}
+
+.hint.success {
+  color: var(--rise);
+}
+
+.loader {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--muted);
+}
+
+.spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.2);
+  border-top-color: var(--accent-2);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 640px) {
+  .result {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .actions {
+    justify-content: space-between;
+  }
+}

--- a/src/app/pages/search/search.component.html
+++ b/src/app/pages/search/search.component.html
@@ -1,0 +1,44 @@
+<div class="search-shell shell">
+  <h2>Find instruments</h2>
+  <form class="search-form" (ngSubmit)="performSearch()">
+    <input
+      type="search"
+      placeholder="Search by symbol or name"
+      [ngModel]="query()"
+      name="query"
+      (ngModelChange)="query.set($event)"
+    />
+    <button class="pill" type="submit" [disabled]="!canSearch()">Search</button>
+  </form>
+  <p class="hint" *ngIf="!touched()">Type at least two characters to start.</p>
+  <p class="hint" *ngIf="feedback()" [class.success]="feedback()?.includes('added')">{{ feedback() }}</p>
+  <div class="loader" *ngIf="loading()">
+    <span class="spinner"></span>
+    <span>Searching instruments…</span>
+  </div>
+  <div class="results" *ngIf="hits().length && !loading()">
+    <div class="result" *ngFor="let hit of hits()">
+      <div>
+        <p class="display">{{ hit.display }}</p>
+        <p class="meta">
+          {{ hit.segment }} · {{ hit.symbol }}
+          <ng-container *ngIf="hit.expiry"> · Exp {{ hit.expiry | date: 'mediumDate' }}</ng-container>
+          <ng-container *ngIf="hit.strike"> · {{ hit.strike | number: '1.0-2' }}</ng-container>
+          <ng-container *ngIf="hit.optionType">{{ hit.optionType }}</ng-container>
+        </p>
+      </div>
+      <div class="actions">
+        <a class="ghost" [routerLink]="['/chart', hit.instrumentKey]">Open chart</a>
+        <button
+          type="button"
+          class="pill"
+          [disabled]="alreadyAdded(hit)"
+          (click)="addToWatchlist(hit)"
+        >
+          {{ alreadyAdded(hit) ? 'In watchlist' : 'Add to watchlist' }}
+        </button>
+      </div>
+    </div>
+  </div>
+  <p class="hint" *ngIf="touched() && !hits().length && !loading()">No matches found.</p>
+</div>

--- a/src/app/pages/search/search.component.ts
+++ b/src/app/pages/search/search.component.ts
@@ -1,0 +1,78 @@
+import { Component, OnInit, signal, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { InstrumentsService, InstrumentHit } from '../../services/instruments.service';
+import { WatchlistService } from '../../services/watchlist.service';
+
+@Component({
+  selector: 'app-search',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink],
+  templateUrl: './search.component.html',
+  styleUrls: ['./search.component.css']
+})
+export class SearchComponent implements OnInit {
+  query = signal('');
+  loading = signal(false);
+  hits = signal<InstrumentHit[]>([]);
+  touched = signal(false);
+  limit = signal(20);
+  feedback = signal<string | null>(null);
+
+  constructor(private instruments: InstrumentsService, private watchlist: WatchlistService) {}
+
+  ngOnInit(): void {
+    if (typeof sessionStorage === 'undefined') {
+      return;
+    }
+    const stored = sessionStorage.getItem('instrument.search.last');
+    if (stored) {
+      this.query.set(stored);
+      this.performSearch();
+    }
+  }
+
+  readonly canSearch = computed(() => this.query().trim().length >= 2 && !this.loading());
+
+  performSearch() {
+    const term = this.query().trim();
+    this.touched.set(true);
+    this.feedback.set(null);
+    if (term.length < 2) {
+      this.hits.set([]);
+      return;
+    }
+    if (typeof sessionStorage !== 'undefined') {
+      sessionStorage.setItem('instrument.search.last', term);
+    }
+    this.loading.set(true);
+    this.instruments.search(term, this.limit()).subscribe({
+      next: hits => {
+        this.hits.set(hits);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.loading.set(false);
+        this.feedback.set('Unable to fetch instruments. Please try again.');
+      }
+    });
+  }
+
+  addToWatchlist(hit: InstrumentHit) {
+    this.watchlist.add({
+      instrumentKey: hit.instrumentKey,
+      display: hit.display,
+      symbol: hit.symbol,
+      segment: hit.segment,
+      expiry: hit.expiry,
+      strike: hit.strike,
+      optionType: hit.optionType
+    });
+    this.feedback.set(`${hit.display} added to watchlist`);
+  }
+
+  alreadyAdded(hit: InstrumentHit) {
+    return this.watchlist.exists(hit.instrumentKey);
+  }
+}

--- a/src/app/pages/watchlist/watchlist.component.css
+++ b/src/app/pages/watchlist/watchlist.component.css
@@ -1,0 +1,78 @@
+.watchlist {
+  width: min(720px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+header h2 {
+  margin: 0;
+}
+
+.ghost {
+  padding: 8px 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text);
+  text-decoration: none;
+}
+
+.hint {
+  color: var(--muted);
+  margin: 0;
+}
+
+.items {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14px 18px;
+  border-radius: 16px;
+  background: rgba(35, 41, 58, 0.85);
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.item:hover {
+  transform: translateY(-2px);
+  background: rgba(45, 52, 72, 0.95);
+}
+
+.symbol {
+  display: flex;
+  flex-direction: column;
+}
+
+.symbol .name {
+  font-weight: 600;
+}
+
+.symbol .meta {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.remove {
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: none;
+  background: rgba(239, 108, 108, 0.18);
+  color: var(--fall);
+  cursor: pointer;
+}
+
+.remove:hover {
+  background: rgba(239, 108, 108, 0.28);
+}

--- a/src/app/pages/watchlist/watchlist.component.html
+++ b/src/app/pages/watchlist/watchlist.component.html
@@ -1,0 +1,18 @@
+<div class="watchlist shell">
+  <header>
+    <h2>Your watchlist</h2>
+    <a class="ghost" routerLink="/search">Add instruments</a>
+  </header>
+  <ng-container *ngIf="items$ | async as items">
+    <p class="hint" *ngIf="!items.length">No instruments added yet. Search to add your favourites.</p>
+    <div class="items" *ngIf="items.length">
+      <div class="item" *ngFor="let item of items" (click)="openChart(item)">
+        <div class="symbol">
+          <span class="name">{{ item.display }}</span>
+          <span class="meta">{{ item.segment }} · {{ item.symbol }}</span>
+        </div>
+        <button class="remove" type="button" (click)="remove(item, $event)">Remove</button>
+      </div>
+    </div>
+  </ng-container>
+</div>

--- a/src/app/pages/watchlist/watchlist.component.ts
+++ b/src/app/pages/watchlist/watchlist.component.ts
@@ -1,0 +1,29 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router, RouterLink } from '@angular/router';
+import { Observable } from 'rxjs';
+import { WatchlistService, WatchlistEntry } from '../../services/watchlist.service';
+
+@Component({
+  selector: 'app-watchlist',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  templateUrl: './watchlist.component.html',
+  styleUrls: ['./watchlist.component.css']
+})
+export class WatchlistComponent {
+  readonly items$: Observable<WatchlistEntry[]>;
+
+  constructor(private watchlist: WatchlistService, private router: Router) {
+    this.items$ = this.watchlist.items$;
+  }
+
+  openChart(item: WatchlistEntry) {
+    this.router.navigate(['/chart', item.instrumentKey]);
+  }
+
+  remove(item: WatchlistEntry, event: MouseEvent) {
+    event.stopPropagation();
+    this.watchlist.remove(item.instrumentKey);
+  }
+}

--- a/src/app/services/instruments.service.ts
+++ b/src/app/services/instruments.service.ts
@@ -1,0 +1,27 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable, map } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface InstrumentHit {
+  display: string;
+  instrumentKey: string;
+  segment: string;
+  symbol: string;
+  expiry?: string | number | null;
+  strike?: number | null;
+  optionType?: string | null;
+}
+
+@Injectable({ providedIn: 'root' })
+export class InstrumentsService {
+  private http = inject(HttpClient);
+  private apiBase = environment.apiBase;
+
+  search(q: string, limit = 20): Observable<InstrumentHit[]> {
+    const params = new HttpParams({ fromObject: { q, limit } });
+    return this.http
+      .get<InstrumentHit[] | { hits: InstrumentHit[] }>(`${this.apiBase}/api/instruments/search`, { params })
+      .pipe(map(res => (Array.isArray(res) ? res : res?.hits ?? [])));
+  }
+}

--- a/src/app/services/market.service.ts
+++ b/src/app/services/market.service.ts
@@ -1,0 +1,120 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable, NgZone, inject } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { webSocket, WebSocketSubject, WebSocketSubjectConfig } from 'rxjs/webSocket';
+import { environment } from '../../environments/environment';
+
+export interface Candle {
+  ts: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume?: number;
+}
+
+export interface Tick {
+  type: 'tick';
+  ts: number;
+  instrumentKey: string;
+  ltp: number;
+  ltq?: number;
+  ltt?: number;
+  cp?: number;
+  bidAsk?: { bidP: number; bidQ: number; askP: number; askQ: number }[];
+  oi?: number;
+  greeks?: { delta: number; theta: number; gamma: number; vega: number; rho: number } | null;
+  ohlc?: {
+    d1?: { o: number; h: number; l: number; c: number; v: number | string; ts: number };
+    i1?: { o: number; h: number; l: number; c: number; v: number | string; ts: number };
+  };
+}
+
+export type Timeframe = '1s' | '1m' | '5m';
+export type WsConnectionState = 'disconnected' | 'connecting' | 'connected';
+
+@Injectable({ providedIn: 'root' })
+export class MarketService {
+  private http = inject(HttpClient);
+  private zone = inject(NgZone);
+  private apiBase = environment.apiBase;
+  private wsBase = environment.apiBase.replace(/^http/, 'ws');
+
+  private readonly connectionStateSubject = new BehaviorSubject<WsConnectionState>('disconnected');
+  private socket?: WebSocketSubject<Tick>;
+
+  readonly connectionState$ = this.connectionStateSubject.asObservable();
+
+  history(instrumentKey: string, tf: Timeframe, limit: number): Observable<Candle[]> {
+    const params = new HttpParams({ fromObject: { instrumentKey, tf, limit } });
+    return this.http
+      .get<Candle[] | { candles: Candle[] }>(`${this.apiBase}/api/market/history`, { params })
+      .pipe(map(res => this.normalizeCandles(Array.isArray(res) ? res : res?.candles ?? [])));
+  }
+
+  connectWs(keys: string[]): WebSocketSubject<Tick> {
+    const filtered = keys.filter(Boolean);
+    if (!filtered.length) {
+      throw new Error('At least one instrument key is required');
+    }
+    if (this.socket) {
+      this.socket.complete();
+    }
+    this.connectionStateSubject.next('connecting');
+    const query = filtered.map(k => encodeURIComponent(k)).join(',');
+    const url = `${this.wsBase}/ws/market?keys=${query}`;
+    const config: WebSocketSubjectConfig<Tick> = {
+      url,
+      deserializer: msg => JSON.parse(msg.data),
+      serializer: value => JSON.stringify(value),
+      openObserver: {
+        next: () => this.zone.run(() => this.connectionStateSubject.next('connected')),
+      },
+      closeObserver: {
+        next: () => this.zone.run(() => this.connectionStateSubject.next('disconnected')),
+      },
+    };
+    this.socket = webSocket<Tick>(config);
+    return this.socket;
+  }
+
+  disconnect() {
+    this.socket?.complete();
+    this.socket = undefined;
+    this.connectionStateSubject.next('disconnected');
+  }
+
+  private normalizeCandles(values: any[]): Candle[] {
+    return values
+      .map(value => {
+        const ts = this.parseTimestamp(value);
+        const open = Number(value.open ?? value.o ?? value.Open ?? value.price_open);
+        const high = Number(value.high ?? value.h ?? value.High ?? value.price_high);
+        const low = Number(value.low ?? value.l ?? value.Low ?? value.price_low);
+        const close = Number(value.close ?? value.c ?? value.Close ?? value.price_close);
+        const volumeRaw = value.volume ?? value.v ?? value.qty;
+        const volume = volumeRaw != null ? Number(volumeRaw) : undefined;
+        if (!Number.isFinite(ts) || !Number.isFinite(open) || !Number.isFinite(high) || !Number.isFinite(low) || !Number.isFinite(close)) {
+          return null;
+        }
+        return { ts, open, high, low, close, volume: volume != null && Number.isFinite(volume) ? volume : undefined } as Candle;
+      })
+      .filter((c): c is Candle => !!c)
+      .sort((a, b) => a.ts - b.ts);
+  }
+
+  private parseTimestamp(value: any): number {
+    const ts = value?.ts ?? value?.time ?? value?.timestamp;
+    if (typeof ts === 'number') {
+      return ts;
+    }
+    if (typeof ts === 'string') {
+      const parsed = Date.parse(ts);
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+    }
+    return Date.now();
+  }
+}

--- a/src/app/services/watchlist.service.ts
+++ b/src/app/services/watchlist.service.ts
@@ -1,0 +1,77 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+export interface WatchlistEntry {
+  instrumentKey: string;
+  display: string;
+  symbol?: string;
+  segment?: string;
+  expiry?: string | number | null;
+  strike?: number | null;
+  optionType?: string | null;
+}
+
+const STORAGE_KEY = 'autobot.watchlist.v1';
+
+@Injectable({ providedIn: 'root' })
+export class WatchlistService {
+  private readonly isBrowser = typeof window !== 'undefined' && typeof localStorage !== 'undefined';
+  private readonly itemsSubject = new BehaviorSubject<WatchlistEntry[]>(this.load());
+
+  readonly items$ = this.itemsSubject.asObservable();
+
+  getAll() {
+    return this.itemsSubject.value;
+  }
+
+  exists(instrumentKey: string) {
+    return this.itemsSubject.value.some(item => item.instrumentKey === instrumentKey);
+  }
+
+  add(entry: WatchlistEntry) {
+    if (this.exists(entry.instrumentKey)) {
+      return;
+    }
+    const next = [...this.itemsSubject.value, entry];
+    this.persist(next);
+  }
+
+  remove(instrumentKey: string) {
+    const next = this.itemsSubject.value.filter(item => item.instrumentKey !== instrumentKey);
+    this.persist(next);
+  }
+
+  clear() {
+    this.persist([]);
+  }
+
+  private persist(items: WatchlistEntry[]) {
+    this.itemsSubject.next(items);
+    if (this.isBrowser) {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+      } catch (err) {
+        console.warn('Failed to persist watchlist', err);
+      }
+    }
+  }
+
+  private load(): WatchlistEntry[] {
+    if (!this.isBrowser) {
+      return [];
+    }
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        return parsed.filter(item => typeof item?.instrumentKey === 'string');
+      }
+    } catch (err) {
+      console.warn('Failed to read watchlist', err);
+    }
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- add navigation updates and routes to surface new search, watchlist, and chart screens
- implement search, watchlist, and chart components with live websocket ticks and history rendering
- provide services for instrument discovery, market history/streaming, and local watchlist persistence

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c92f6b604c832fb52bba7d2fad9cd0